### PR TITLE
Add Palette Colors swap option, update README, and 20260722 release

### DIFF
--- a/Arduboy.sv
+++ b/Arduboy.sv
@@ -226,7 +226,7 @@ end
 // 0         1         2         3          4         5         6
 // 01234567890123456789012345678901 23456789012345678901234567890123
 // 0123456789ABCDEFGHIJKLMNOPQRSTUV 0123456789ABCDEFGHIJKLMNOPQRSTUV
-// XXXXXX  XX     XX
+// XXXXXXX XX     XX
 
 `include "build_id.v"
 localparam CONF_STR =
@@ -241,6 +241,7 @@ localparam CONF_STR =
     "-;",
     "O2,Custom Palette,Off,On;",
     "D0FC1,GBP,Load Palette;",
+    "D0O6,Palette Colors,Normal,Swapped;",
     "-;",
     "R0,Reset;",
     "J1,A,B;",
@@ -378,8 +379,8 @@ reg [127:0] palette = 128'hFFFFFF00000000000000000000000000; // default: stock w
 
 always @ (posedge clk_sys) if (palette_download & ioctl_wr) palette <= {palette[119:0], ioctl_dout};
 
-wire [23:0] color_fg = palette[127:104];
-wire [23:0] color_bg = palette[55:32];
+wire [23:0] color_fg = status[6] ? palette[55:32]   : palette[127:104];
+wire [23:0] color_bg = status[6] ? palette[127:104] : palette[55:32];
 
 arcade_video #(256,24) arcade_video
 (

--- a/README.md
+++ b/README.md
@@ -4,12 +4,68 @@ Arduboy core for MiSTer, ported by Dan O'Shea and based on Iulian Gheorghiu's at
 
 https://github.com/MorgothCreator/atmega-xmega-soft-core
 
-A collection of .bin files converted and tested so far can be found here (you can hit the green 'Clone or download' button, and then 'Download ZIP' to get them all at once):
+## Loading games
+
+Games can be loaded from anywhere on the SD card, but are most conveniently kept in
+`/media/fat/games/Arduboy`. Both Intel HEX (`.hex`) and raw binary (`.bin`) files load
+directly - no conversion needed.
+
+A collection of `.bin` files converted and tested so far can be found here (you can hit the
+green 'Clone or download' button, and then 'Download ZIP' to get them all at once):
 
 https://github.com/uXeBoy/ArduboyCollection
 
-Arduboy .hex files first need to be converted to .bin using hex2bin (and be sure to use the command line option `-l 8000` to pad the files out to 32K):
+If you prefer to convert `.hex` to `.bin` yourself, use hex2bin with the command line option
+`-l 8000` to pad the file out to 32K:
 
 https://sourceforge.net/projects/hex2bin/
 
-TODO: work on more complete sound support, look at making EEPROM non-volatile, improve stability (some games will randomly reset, or not run at all), pull requests / improvements welcome!
+The core boots with Arduventure built in, so it will run without loading anything.
+
+## Options
+
+**Orientation** - `Horizontal` / `Vertical`. Rotates the display for games designed to be
+played with the Arduboy held on its side; the D-pad is remapped to match.
+
+**Aspect ratio** - `Original` / `Full Screen`, plus the two user-defined MiSTer ratios.
+
+**Scandoubler Fx** - `None` / `HQ2x` / `CRT 25%` / `CRT 50%` / `CRT 75%`.
+
+**ADC** - `Random` / `AnalogStick` / `Paddle`. Selects what feeds the ATmega's analog input.
+`Random` leaves it unconnected, which is what most games expect. Choose one of the others only
+for games that actually read the ADC as a control.
+
+### Custom palette
+
+The Arduboy display is 1-bit: every pixel is either lit or unlit. By default the core renders
+that as white on black, but it can be colorized instead.
+
+**Custom Palette** - `Off` / `On`. Turning it on reveals the two options below.
+
+**Load Palette** - loads a `.gbp` palette file. As with games these can live anywhere on the SD
+card, but are most conveniently kept in `/media/fat/games/Arduboy/Palettes`. The first color in
+the file becomes the lit (foreground) color and the fourth becomes the unlit (background) color.
+Loading a palette does not reset the running game, so palettes can be auditioned while playing.
+
+**Palette Colors** - `Normal` / `Swapped`. Exchanges the foreground and background colors.
+Because a set pixel means different things in different games - some titles draw light artwork
+on a dark field, others the reverse - a single fixed assignment cannot suit every game. Leave
+this on `Normal` unless a palette comes out inverted.
+
+With Custom Palette on and no file loaded, the default is the stock white on black, so
+`Swapped` alone gives black on white.
+
+## Controls
+
+| Arduboy | MiSTer |
+|---------|--------|
+| D-pad   | D-pad / stick |
+| A       | Button 1 |
+| B       | Button 2 |
+
+The RGB LED is mapped to the MiSTer board LEDs.
+
+## TODO
+
+Work on more complete sound support, look at making EEPROM non-volatile, improve stability
+(some games will randomly reset, or not run at all), pull requests / improvements welcome!


### PR DESCRIPTION
Three related changes, one commit each so they can be taken separately if preferred.

### 1. Palette Colors: Normal / Swapped

Adds a sub-option under Custom Palette that exchanges the foreground and background
colors of a loaded `.gbp` palette. (See attached pictures for reference)
<img width="4032" height="3024" alt="IMG_0625" src="https://github.com/user-attachments/assets/e9e1ef72-c90b-439c-8e19-36e52eb99387" />
<img width="5712" height="4284" alt="IMG_0623" src="https://github.com/user-attachments/assets/d09a034b-2d9d-4e9e-aab7-56363ebaa982" />
<img width="4032" height="3024" alt="IMG_0624" src="https://github.com/user-attachments/assets/c2d06084-d4a7-45bc-8aaa-e10ddbc0a3d7" />


The Arduboy display is 1-bit, and games disagree about what a set pixel means: some
draw light artwork on a dark field, others the reverse. A single fixed mapping from
palette slots to foreground/background therefore cannot suit every game, and some
titles come out looking inverted under any one choice. This option lets the user
correct that per game rather than per palette file.

- New status bit 6, `"D0O6,Palette Colors,Normal,Swapped;"`
- Reuses the existing `status_menumask`, so the entry hides along with Load Palette
  when Custom Palette is Off. No `hps_io` change.
- **`Normal` is the default and preserves current behavior exactly.** Existing palette
  files render identically to before; nobody's setup changes unless they opt in.

Nine added lines in `Arduboy.sv`, no new modules, ports, or clocked logic.

### 2. README

Adds an options section (orientation, aspect ratio, scandoubler fx, ADC, and the
palette settings), the conventional locations for game and palette files, and a
controls table.

It also corrects the loading instructions. The README still tells users that `.hex`
files must be converted to `.bin` with hex2bin first, which stopped being true when
HEX loading was added - the core has accepted `.hex` directly ever since. The
conversion note is kept as optional rather than removed, since the `-l 8000` padding
advice still applies to anyone who does convert.

### 3. Release 20260722

`releases/Arduboy_20260722.rbf`, built from the palette commit in this PR.

Worth noting: the newest release in the repo is 20250824, which predates the custom
palette support merged in #11. This is the first released binary to include it, so it
picks up both features for users who don't compile their own cores.

---

### Testing

Compiled with Quartus Prime Lite 17.0.2 (Cyclone V, 5CSEBA6U23I7): **0 errors**. No new
warnings attributable to this change; the inferred-latch messages in the map report are
pre-existing in `rtl/avr` (`mega-core.v`, `atmega-tim-10bit.v`) and unrelated. No
inferred latches or multiple-driver findings in `Arduboy.sv`.

Fitter: 10,561 ALMs (25%), 109 RAM blocks (20%), 37 DSP (33%) - within noise of the
same build without this change (10,572 ALMs), as expected since the new select folds
into an existing mux.

Tested on real MiSTer hardware:

1. Custom Palette Off - display is white on black, unchanged.
2. Custom Palette Off - both Load Palette and Palette Colors are hidden; On - both appear.
3. `.gbp` loaded, Palette Colors Normal - renders identically to before this change.
4. Palette Colors Swapped - foreground and background exchange immediately, no game reset.
5. Toggling back to Normal restores the previous colors.
6. Custom Palette On with no file loaded - Normal gives white on black, Swapped black on white.
7. Regression - orientation, scandoubler fx, aspect ratio, and both `.bin` and `.hex`
   game loading all still work.

Happy to split any of the three commits into a separate PR, or to rebuild the release
binary if the code changes during review.