### PR TITLE
Fix NEG half-carry flag (DS40002198 §6.80.2)

### DIFF
--- a/rtl/avr/mega-alu.v
+++ b/rtl/avr/mega-alu.v
@@ -230,7 +230,7 @@ begin
         begin
             R[7:0] = 8'h00 - rd[7:0];
             sreg_out[`XMEGA_FLAG_C] = |R[7:0];
-            sreg_out[`XMEGA_FLAG_H] = R[3] | ~rd[3];
+            sreg_out[`XMEGA_FLAG_H] = R[3] | rd[3];
             sreg_out[`XMEGA_FLAG_V] = &{R[7], ~R[6:0]};
             sreg_out[`XMEGA_FLAG_N] = R[7];
             sreg_out[`XMEGA_FLAG_S] = sreg_out[`XMEGA_FLAG_N] ^ sreg_out[`XMEGA_FLAG_V];


### PR DESCRIPTION
`rtl/avr/mega-alu.v` computes NEG's half-carry as `R[3] | ~rd[3]`. DS40002198 §6.80.2
defines it as H = R3 ∨ Rd3 — no complement on the operand bit.

The inversion is masked whenever R3 = 1, so H is wrong for exactly the 128 operands
with R3 = 0: 112 wrongly clear, 16 wrongly set. Not device-specific — NEG's H is
defined identically across the 8-bit AVR family.

Verified three ways: a per-instruction conformance run against the manual's vectors
(this was the sole unexpected failure before the change, passes after, every mismatch
on the H bit); Quartus 17.0.2 clean with fitter resources unchanged; and an on-hardware
test ROM over five R3 = 0 edge values, which passes on the patched core and fails on
stock.

Practical impact is limited — H is consumed mainly by BCD sequences after ADD/ADC — but
the flag did not match the spec.