### PR TITLE
atmega-eep: initialize EEPROM to 0xFF instead of a dangling ram_init_file

### DIFF
--- a/rtl/avr/atmega-eep.v
+++ b/rtl/avr/atmega-eep.v
@@ -49,8 +49,14 @@ module atmega_eep # (
     );
 
 // EEPROM_SYS_FLAGS_SHOW_LOGO_LEDS / EEPROM_AUDIO_ON
-(* ram_init_file = "EEPROM.mif" *)
 reg [7:0]eep[EEP_SIZE-1 : 0];
+
+// Real ATmega32U4 EEPROM reads 0xFF when erased; Arduboy2 depends on that
+// for its boot-logo and audio-on defaults (eepromSysFlags/eepromAudioOnOff).
+integer eep_init_i;
+initial
+    for(eep_init_i = 0; eep_init_i < EEP_SIZE; eep_init_i = eep_init_i + 1)
+        eep[eep_init_i] = 8'hFF;
 
 reg [7:0]EEARH;
 reg [7:0]EEARL;


### PR DESCRIPTION
eep[] pointed ram_init_file at "EEPROM.mif", a file that has never existed in this repository (confirmed against git history and .gitignore). Quartus silently falls back to zero-filling on every build, including the shipped 20250824 release (Critical Warning (127003), confirmed in existing build logs).

Real ATmega32U4 EEPROM reads 0xFF when erased (DS40002198/Atmel-7766J Sec 28.6.2), and Arduboy2 depends on that: begin() calls bootLogo() and audio.begin() unconditionally, gated on EEPROM byte 1 (logo) and byte 2 (audio) reading nonzero. Both default to "off" on a zero-filled EEPROM -- the opposite of real hardware -- so every game booted with the logo suppressed and audio muted.

Replace the dangling attribute with an explicit initial for-loop setting every byte to 8'hFF, mirroring the idiom already used in mega-reg.v. No read/write logic touched.

Verified in simulation: Verilator lint identical before/after; direct simulation confirms all 512 bytes read 0xFF at time 0. Compiled clean on 2 seeds (0 errors, Critical Warning count 9->8, EEPROM.mif warning gone).

Hardware-confirmed on a MiSTer: audio on by default (Ardynia SFX option); logo now appears on titles that use the default begin() path and did not before (e.g. github.com/sebastianscaini/Arduboy-Visual-Novel-Demo), with no change on titles already showing it or bypassing begin() entirely (e.g. github.com/city41/ardynia, which never calls bootLogo()).