### PR TITLE
atmega-tim-10bit: remove dead OC4C modeling; fix clock-mux sensitivity list

### DIFF
--- a/rtl/avr/atmega-tim-10bit.v
+++ b/rtl/avr/atmega-tim-10bit.v
@@ -110,20 +110,15 @@ module atmega_tim_10bit # (
     input ocra_int_rst,
     output ocrb_int,
     input ocrb_int_rst,
-    output ocrc_int,
-    input ocrc_int_rst,
     output ocrd_int,
     input ocrd_int_rst,
     output reg oca,
     output reg ocb,
-    output reg occ,
     output reg ocd,
     output ocap_io_connect,
     output ocan_io_connect,
     output ocbp_io_connect,
     output ocbn_io_connect,
-    output occp_io_connect,
-    output occn_io_connect,
     output ocdp_io_connect,
     output ocdn_io_connect
     );
@@ -154,8 +149,6 @@ reg ocra_p;
 reg ocra_n;
 reg ocrb_p;
 reg ocrb_n;
-reg ocrc_p;
-reg ocrc_n;
 reg ocrd_p;
 reg ocrd_n;
 
@@ -300,13 +293,10 @@ begin
         ocra_n <= 1'b0;
         ocrb_p <= 1'b0;
         ocrb_n <= 1'b0;
-        ocrc_p <= 1'b0;
-        ocrc_n <= 1'b0;
         ocrd_p <= 1'b0;
         ocrd_n <= 1'b0;
         oca <= 1'b0;
         ocb <= 1'b0;
-        occ <= 1'b0;
         ocd <= 1'b0;
         up_count <= 1'b1;
         clk_int_del <= 1'b0;
@@ -328,11 +318,6 @@ begin
             TIFR[`OCF0B] <= 1'b1;
             ocrb_n <= ocrb_p;
         end
-        if(ocrc_p ^ ocrc_n)
-        begin
-            TIFR[`OCF0C] <= 1'b1;
-            ocrc_n <= ocrc_p;
-        end
         if(ocrd_p ^ ocrd_n)
         begin
             TIFR[`OCF0D] <= 1'b1;
@@ -349,10 +334,6 @@ begin
         if(ocrb_int_rst)
         begin
             TIFR[`OCF0B] <= 1'b0;
-        end
-        if(ocrc_int_rst)
-        begin
-            TIFR[`OCF0C] <= 1'b0;
         end
         if(ocrd_int_rst)
         begin
@@ -642,15 +623,12 @@ end
 assign tov_int = TIFR[`TOV0];
 assign ocra_int = TIFR[`OCF0A];
 assign ocrb_int = TIFR[`OCF0B];
-assign ocrc_int = TIFR[`OCF0C];
 assign ocrd_int = TIFR[`OCF0D];
 
 assign ocap_io_connect = USE_OCRA == "TRUE" ? ((TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
 assign ocan_io_connect = USE_OCRA == "TRUE" ? ((TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
 assign ocbp_io_connect = USE_OCRB == "TRUE" ? ((TCCRA[`COM0B1:`COM0B0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
 assign ocbn_io_connect = USE_OCRB == "TRUE" ? ((TCCRA[`COM0B1:`COM0B0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
-assign occp_io_connect = 1'b0;//(TCCRA[`COM0C1:`COM0C0] == 2'b00 || TCCRA[`COM0C1:`COM0C0] == 2'b01) ? 1'b0 : 1'b1;
-assign occn_io_connect = 1'b0;//(TCCRA[`COM0C1:`COM0C0] == 2'b00 || TCCRA[`COM0C1:`COM0C0] == 2'b01) ? 1'b0 : 1'b1;
 assign ocdp_io_connect = USE_OCRD == "TRUE" ? ((TCCRC[`COM0D1:`COM0D0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
 assign ocdn_io_connect = USE_OCRD == "TRUE" ? ((TCCRC[`COM0D1:`COM0D0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
 

--- a/rtl/avr/atmega-tim-10bit.v
+++ b/rtl/avr/atmega-tim-10bit.v
@@ -185,7 +185,6 @@ end
 
 /* Prescaller selection implementation */
 wire [15:0]tim_clks = {presc_cnt, clk_pll, 1'b0};
-wire timer_clk = pll_enabled ? clk_pll : clk;
 always @ *
 begin
     clk_int = tim_clks[TCCRB[`CS03:`CS00]];
@@ -273,7 +272,7 @@ begin
 end
 
 /* Set "oc" pin on specified conditions*/
-always @ (posedge rst or posedge timer_clk)
+always @ (posedge rst or posedge clk)
 begin
     if(rst)
     begin

--- a/rtl/avr/atmega-tim-10bit.v
+++ b/rtl/avr/atmega-tim-10bit.v
@@ -185,6 +185,7 @@ end
 
 /* Prescaller selection implementation */
 wire [15:0]tim_clks = {presc_cnt, clk_pll, 1'b0};
+wire timer_clk = pll_enabled ? clk_pll : clk;
 always @ *
 begin
     clk_int = tim_clks[TCCRB[`CS03:`CS00]];
@@ -272,7 +273,7 @@ begin
 end
 
 /* Set "oc" pin on specified conditions*/
-always @ (posedge rst or posedge pll_enabled ? clk_pll : clk)
+always @ (posedge rst or posedge timer_clk)
 begin
     if(rst)
     begin

--- a/rtl/avr/atmega32u4.v
+++ b/rtl/avr/atmega32u4.v
@@ -142,8 +142,6 @@ wire tim4_ocap_io_connect;
 wire tim4_ocan_io_connect;
 wire tim4_ocbp_io_connect;
 wire tim4_ocbn_io_connect;
-wire tim4_occp_io_connect;
-wire tim4_occn_io_connect;
 wire tim4_ocdp_io_connect;
 wire tim4_ocdn_io_connect;
 wire uart_tx_io_connect;
@@ -162,7 +160,6 @@ wire tim3_ocb;
 wire tim3_occ;
 wire tim4_oca;
 wire tim4_ocb;
-wire tim4_occ;
 wire tim4_ocd;
 wire spi_miso;
 wire usb_ck_out;
@@ -830,20 +827,15 @@ atmega_tim_10bit # (
     .ocra_int_rst(int_timer4_compa_rst),
     .ocrb_int(int_timer4_compb),
     .ocrb_int_rst(int_timer4_compb_rst),
-    .ocrc_int(),
-    .ocrc_int_rst(),
     .ocrd_int(int_timer4_compd),
     .ocrd_int_rst(int_timer4_compd_rst),
     .oca(tim4_oca),
     .ocb(tim4_ocb),
-    .occ(tim4_occ),
     .ocd(tim4_ocd),
     .ocap_io_connect(tim4_ocap_io_connect),
     .ocan_io_connect(tim4_ocan_io_connect),
     .ocbp_io_connect(tim4_ocbp_io_connect),
     .ocbn_io_connect(tim4_ocbn_io_connect),
-    .occp_io_connect(tim4_occp_io_connect),
-    .occn_io_connect(tim4_occn_io_connect),
     .ocdp_io_connect(tim4_ocdp_io_connect),
     .ocdn_io_connect(tim4_ocdn_io_connect)
     );


### PR DESCRIPTION
Real ATmega32U4 Timer4 has only three output-compare channels (TCCR4A/TCCR4C/TIMSK4/TIFR4 — A/B/D, no C). occ/ocrc_p were never assigned outside reset, inferred as transparent latches by Quartus (Info 10041, atmega-tim-10bit.v:275). avr-objdump on BeamEmUp.hex, BeamEmUp-release.hex, ardynia_1.1.0.hex confirms zero real games touch Timer4's compare logic.

Also fixes a malformed sensitivity list in the same block (posedge pll_enabled ? clk_pll : clk parses as posedge rst or (posedge pll_enabled ? clk_pll : clk), not the intended mux) and drops the clk_pll branch — pll_enabled is hardwired 0 for this core, so it always resolved to clk anyway.

0 errors, 3 fewer latch warnings, hardware-tested with no observable behavior change.