### PR TITLE
Fix SREG corruption from stale address check on STS

### DIFF
--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -513,7 +513,10 @@ begin
 					end
 					{1'b1, `STEP1, `INSTRUCTION_STS}:
 					begin
-						case(data_addr_int)
+						// Real "STS 0x5F, Rr" (direct write to SREG). Uses the freshly-decoded
+						// address, not the registered data_addr_int (not updated until this
+						// same STEP1 -- see the data_addr_int-setting casex further down).
+						case(ROM_ADDR_WIDTH > 16 ? {RAMPD, pgm_data_int} : pgm_data_int)
 							24'h05F: SREG <= reg_rs1;
 						endcase
 					end


### PR DESCRIPTION
An \`STS\` immediately following an \`IN\`/\`OUT\` addressing SREG — the standard \`cli()\`-protected atomic-read idiom avr-libc uses for \`millis()\`/\`micros()\` — could clobber SREG (including the interrupt-enable bit) with unrelated data. The STS-to-SREG special case in mega-core.v checked \`data_addr_int\` before it was updated for the current instruction. Verified with a minimal 11-instruction isolated repro; hardware-confirmed fixing a permanent hang in ArduMetronome, no regressions in 4 other games.