### PR TITLE
Fix speaker pin wiring silencing audio in several games

### DIFF
--- a/rtl/avr/atmega-tim-16bit.v
+++ b/rtl/avr/atmega-tim-16bit.v
@@ -675,7 +675,12 @@ assign ocra_int = TIFR[`OCF0A];
 assign ocrb_int = TIFR[`OCF0B];
 assign ocrc_int = TIFR[`OCF0C];
 
-assign oca_io_connect = (TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : (TCCRA[`COM0A1:`COM0A0] == 2'b01 ? (({TCCRA[`WGM03:`WGM02], TCCRA[`WGM01:`WGM00]} == 4'd14 || {TCCRA[`WGM03:`WGM02], TCCRA[`WGM01:`WGM00]} == 4'd15) ? 1'b1 : 1'b0) : 1'b1);
+// COM=01 connects OCA to the pin only for these WGM modes (ATmega32U4 datasheet Tables 14-1/14-2/14-3).
+wire [3:0] wgm_value = {TCCRB[`WGM03:`WGM02], TCCRA[`WGM01:`WGM00]};
+assign oca_io_connect = (TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : (TCCRA[`COM0A1:`COM0A0] == 2'b01 ?
+    ((wgm_value == 4'd0)  || (wgm_value == 4'd4)  || (wgm_value == 4'd8)  ||
+     (wgm_value == 4'd9)  || (wgm_value == 4'd10) || (wgm_value == 4'd11) ||
+     (wgm_value == 4'd12) || (wgm_value == 4'd14) || (wgm_value == 4'd15) ? 1'b1 : 1'b0) : 1'b1);
 assign ocb_io_connect = (TCCRA[`COM0B1:`COM0B0] == 2'b00 || TCCRA[`COM0B1:`COM0B0] == 2'b01) ? 1'b0 : 1'b1;
 assign occ_io_connect = (TCCRA[`COM0C1:`COM0C0] == 2'b00 || TCCRA[`COM0C1:`COM0C0] == 2'b01) ? 1'b0 : 1'b1;
 

--- a/rtl/avr/atmega32u4.v
+++ b/rtl/avr/atmega32u4.v
@@ -178,8 +178,9 @@ assign RGB[2] = tim1_ocb_io_connect ? tim1_ocb : ~(pb_out[6]);
 assign RGB[1] = tim0_oca_io_connect ? ~tim0_oca : ~(pb_out[7]);
 assign RGB[0] = tim1_oca_io_connect ? tim1_oca : ~(pb_out[5]);
 
-assign Buzzer1 = pc_out[6];
-assign Buzzer2 = tim4_ocap_io_connect ? tim4_oca : 1'b0;
+// Fall through to GPIO when the timer output is disconnected, same as the RGB LED pins above.
+assign Buzzer1 = tim3_oca_io_connect ? tim3_oca : pc_out[6];
+assign Buzzer2 = tim4_ocap_io_connect ? tim4_oca : pc_out[7];
 assign DC = pd_out[4];
 
 /* Interrupt wires */


### PR DESCRIPTION
\`Buzzer2\` was hardwired to 0 whenever Timer4's OC4A is disconnected (the default state for any game that never touches Timer4) instead of falling through to real GPIO. \`Buzzer1\` never wired in Timer3's real hardware compare-output-toggle at all, requiring a related fix to \`oca_io_connect\`'s WGM-mode logic (wrong register read, missing Normal/CTC case). Hardware-confirmed: restores sound in ArduBOYNG, Bangi, Festive Fight, Glove, Helii, To/The Door, and Trench Run, no regressions.