### PR TITLE
Fix TCNT/TIFR write gaps on Timer1/3, port OCF-gating fix to Timer0/Timer4

### DIFF
--- a/rtl/avr/atmega-tim-10bit.v
+++ b/rtl/avr/atmega-tim-10bit.v
@@ -395,16 +395,8 @@ begin
                             endcase
                         end
                     endcase
-                    if(TIMSK[`OCIE0A])
-                    begin
-                        if(ocra_p == ocra_n && clk_active == 1'b1)
-                            ocra_p <= ~ocra_p;
-                    end
-                    else
-                    begin
-                        ocra_p <= 1'b0;
-                        ocra_n <= 1'b0;
-                    end
+                    if(ocra_p == ocra_n && clk_active == 1'b1)
+                        ocra_p <= ~ocra_p;
                 end
                 else if(TCCRD[`WGM00] & TCCRA[`PWMA] & {TCH, TCNTL} == 10'h000)
                     oca <= 1'b0;
@@ -458,16 +450,8 @@ begin
                             endcase
                         end
                     endcase
-                    if(TIMSK[`OCIE0B])
-                    begin
-                        if(ocrb_p == ocrb_n && clk_active == 1'b1)
-                            ocrb_p <= ~ocrb_p;
-                    end
-                    else
-                    begin
-                        ocrb_p <= 1'b0;
-                        ocrb_n <= 1'b0;
-                    end
+                    if(ocrb_p == ocrb_n && clk_active == 1'b1)
+                        ocrb_p <= ~ocrb_p;
                 end
                 else if(TCCRD[`WGM00] & TCCRA[`PWMB] & {TCH, TCNTL} == 10'h000)
                     oca <= 1'b0;
@@ -525,16 +509,8 @@ begin
                             endcase
                         end
                     endcase
-                    if(TIMSK[`OCIE0D])
-                    begin
-                        if(ocrd_p == ocrd_n && clk_active == 1'b1)
-                            ocrd_p <= ~ocrd_p;
-                    end
-                    else
-                    begin
-                        ocrd_p <= 1'b0;
-                        ocrd_n <= 1'b0;
-                    end
+                    if(ocrd_p == ocrd_n && clk_active == 1'b1)
+                        ocrd_p <= ~ocrd_p;
                 end
                 else if(TCCRD[`WGM00] & TCCRA[`PWMD] & {TCH, TCNTL} == 10'h000)
                     oca <= 1'b0;
@@ -542,16 +518,8 @@ begin
             // TCNT overflow logick.
             if(&{{TCH, TCNTL} == t_ovf_value, ~halt})
             begin
-                if(TIMSK[`TOIE0])
-                begin
-                    if(tov_p == tov_n && clk_active == 1'b1)
-                        tov_p <= ~tov_p;
-                end
-                else
-                begin
-                    tov_p <= 1'b0;
-                    tov_n <= 1'b0;
-                end
+                if(tov_p == tov_n && clk_active == 1'b1)
+                    tov_p <= ~tov_p;
             end
             if(&{{TCH, TCNTL} == top_value, ~halt})
             begin
@@ -620,10 +588,10 @@ begin
     end
 end
 
-assign tov_int = TIFR[`TOV0];
-assign ocra_int = TIFR[`OCF0A];
-assign ocrb_int = TIFR[`OCF0B];
-assign ocrd_int = TIFR[`OCF0D];
+assign tov_int = TIFR[`TOV0] & TIMSK[`TOIE0];
+assign ocra_int = TIFR[`OCF0A] & TIMSK[`OCIE0A];
+assign ocrb_int = TIFR[`OCF0B] & TIMSK[`OCIE0B];
+assign ocrd_int = TIFR[`OCF0D] & TIMSK[`OCIE0D];
 
 assign ocap_io_connect = USE_OCRA == "TRUE" ? ((TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;
 assign ocan_io_connect = USE_OCRA == "TRUE" ? ((TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : 1'b1) : 1'b0;

--- a/rtl/avr/atmega-tim-16bit.v
+++ b/rtl/avr/atmega-tim-16bit.v
@@ -608,7 +608,7 @@ begin
                 begin
                     TCCRC <= bus_dat_in;
                 end
-/*              TCNTL_ADDR:
+                TCNTL_ADDR:
                 begin
                     TCNT <= (TMP_REG_addr == TCNTH_ADDR) ? {TMP_REG_wr, bus_dat_in} : {8'd0, bus_dat_in};
                 end
@@ -616,7 +616,7 @@ begin
                 begin
                     TMP_REG_wr <= bus_dat_in;
                     TMP_REG_addr <= TCNTH_ADDR;
-                end */
+                end
                 ICRL_ADDR:
                 begin
                     ICR <= (TMP_REG_addr == ICRH_ADDR) ? {TMP_REG_wr, bus_dat_in} : {8'd0, bus_dat_in};
@@ -643,8 +643,10 @@ begin
                 OCRBH_ADDR:
                 begin
                     if(USE_OCRB == "TRUE")
+                    begin
                         TMP_REG_wr <= bus_dat_in;
                         TMP_REG_addr <= OCRBH_ADDR;
+                    end
                 end
                 OCRCL_ADDR:
                 begin
@@ -654,13 +656,15 @@ begin
                 OCRCH_ADDR:
                 begin
                     if(USE_OCRC == "TRUE")
+                    begin
                         TMP_REG_wr <= bus_dat_in;
                         TMP_REG_addr <= OCRCH_ADDR;
+                    end
                 end
-/*              TIFR_ADDR:
+                TIFR_ADDR:
                 begin
                     TIFR <= TIFR & ~bus_dat_in;
-                end */
+                end
                 TIMSK_ADDR:
                 begin
                     TIMSK <= bus_dat_in;

--- a/rtl/avr/atmega-tim-8bit.v
+++ b/rtl/avr/atmega-tim-8bit.v
@@ -320,16 +320,8 @@ begin
                         endcase
                     end
                 endcase
-                if(TIMSK[`OCIE0A] == 1'b1)
-                begin
-                    if(ocra_p == ocra_n && clk_active == 1'b1)
-                        ocra_p <= ~ocra_p;
-                    else
-                    begin
-                        ocra_p <= 1'b0;
-                        ocra_n <= 1'b0;
-                    end
-                end
+                if(ocra_p == ocra_n && clk_active == 1'b1)
+                    ocra_p <= ~ocra_p;
             end
             // !OCRA
             if(USE_OCRB == "TRUE")
@@ -368,31 +360,15 @@ begin
                             endcase
                         end
                     endcase
-                    if(TIMSK[`OCIE0B] == 1'b1)
-                    begin
-                        if(ocrb_p == ocrb_n && clk_active == 1'b1)
-                            ocrb_p <= ~ocrb_p;
-                    end
-                    else
-                    begin
-                        ocrb_p <= 1'b0;
-                        ocrb_n <= 1'b0;
-                    end
+                    if(ocrb_p == ocrb_n && clk_active == 1'b1)
+                        ocrb_p <= ~ocrb_p;
                 end
             end // USE_OCRB != "TRUE"
             // TCNT overflow logick.
             if(&{TCNT == t_ovf_value, ~halt})
             begin
-                if(TIMSK[`TOIE0] == 1'b1)
-                begin
-                    if(tov_p == tov_n && clk_active == 1'b1)
-                        tov_p <= ~tov_p;
-                end
-                else
-                begin
-                    tov_p <= 1'b0;
-                    tov_n <= 1'b0;
-                end
+                if(tov_p == tov_n && clk_active == 1'b1)
+                    tov_p <= ~tov_p;
             end
             if(&{TCNT == top_value, ~halt})
             begin
@@ -434,9 +410,9 @@ begin
     end
 end
 
-assign tov_int = TIFR[`TOV0];
-assign ocra_int = TIFR[`OCF0A];
-assign ocrb_int = TIFR[`OCF0B];
+assign tov_int = TIFR[`TOV0] & TIMSK[`TOIE0];
+assign ocra_int = TIFR[`OCF0A] & TIMSK[`OCIE0A];
+assign ocrb_int = TIFR[`OCF0B] & TIMSK[`OCIE0B];
 
 assign oca_io_connect = (TCCRA[`COM0A1:`COM0A0] == 2'b00) ? 1'b0 : (TCCRA[`COM0A1:`COM0A0] == 2'b01 ? ((TCCRA[`WGM01:`WGM00] == 2'd1 || TCCRA[`WGM01:`WGM00] == 2'd3) ? TCCRB[`WGM02] : 1'b1) : 1'b1);
 assign ocb_io_connect = USE_OCRB == "TRUE" ? ((TCCRA[`COM0B1:`COM0B0] == 2'b00) ? 1'b0 : (TCCRA[`COM0B1:`COM0B0] == 2'b01 ? ((TCCRA[`WGM01:`WGM00] == 2'd1 || TCCRA[`WGM01:`WGM00] == 2'd3) ? TCCRB[`WGM02] : 1'b1) : 1'b1)) : 1'b0;


### PR DESCRIPTION
Two related gaps, found checking whether Timer0's OCF-gating fix (#18) and the Timer1/3 TCNT/TIFR gaps generalized to the other timers: TCNT direct-write and TIFR write-1-to-clear on Timer1/3 were correct, already-written code sitting in a comment block (uncommented, no new logic); Timer0 and Timer4 had the same OCFnA/B/C-gated-on-TIMSK bug as #18, same fix ported. Also fixes a dangling-if scoping bug in OCRBH_ADDR/OCRCH_ADDR (TMP_REG_addr updated unconditionally instead of only under USE_OCRB/USE_OCRC), confirmed by Verilator's MISINDENT warning clearing.

4 new testbenches, including a replay of ArduboyPlaytune's real per-note TCNT3=0 write (currently a no-op in Ardynia; this makes it live). Hardware-confirmed on Ardynia, CastleBoy, Mystic Balloon, Beam 'Em Up, ArduMetronome — no regressions.