### PR TITLE
Split ATmega32U4 into a real-pin-accurate reusable module + Arduboy board wiring

### DIFF
--- a/Arduboy.sv
+++ b/Arduboy.sv
@@ -336,12 +336,7 @@ end
 wire Buzzer1, Buzzer2;
 wire oled_dc, oled_clk, oled_data;
 
-// Reconstructs the pre-rename 3-bit RGB output exactly, bit for bit (RGB[2]=PB6, RGB[1]=PB7,
-// RGB[0]=PB5 inside atmega32u4.v) so the {LED_USER, LED_DISK[0]} width mismatch below resolves
-// identically to the pre-rename connection instead of being re-guessed.
-wire [2:0] avr_rgb_out;
-
-atmega32u4 atmega32u4
+arduboy_board arduboy_board
 (
     .clk(clk_avr),
     .rst(reset),
@@ -350,19 +345,15 @@ atmega32u4 atmega32u4
     .buttons(~(status[1] ? {joystick[5:4], joystick[1], joystick[0], joystick[2], joystick[3]} : joystick[5:0])),
     .joystick_analog(status[16] ? {~paddle[7],paddle[6:0]} : joystick_analog[7:0]),
     .status(|status[16:15]),
-    .PB6(avr_rgb_out[2]),
-    .PB7(avr_rgb_out[1]),
-    .PB5(avr_rgb_out[0]),
-    .PC6(Buzzer1),
-    .PC7(Buzzer2),
-    .PD4(oled_dc),
-    .PB1(oled_clk),
-    .PB2(oled_data),
-    .PD2(USER_IN[0]),
-    .PD3(USER_OUT[1])
+    .RGB({LED_USER, LED_DISK[0]}),
+    .Buzzer1(Buzzer1),
+    .Buzzer2(Buzzer2),
+    .DC(oled_dc),
+    .spi_scl(oled_clk),
+    .spi_mosi(oled_data),
+    .uart_rx(USER_IN[0]),
+    .uart_tx(USER_OUT[1])
 );
-
-assign {LED_USER, LED_DISK[0]} = avr_rgb_out;
 
 wire pixelValue, ce_pix;
 wire VSync, HSync, HBlank, VBlank;

--- a/Arduboy.sv
+++ b/Arduboy.sv
@@ -336,6 +336,11 @@ end
 wire Buzzer1, Buzzer2;
 wire oled_dc, oled_clk, oled_data;
 
+// Reconstructs the pre-rename 3-bit RGB output exactly, bit for bit (RGB[2]=PB6, RGB[1]=PB7,
+// RGB[0]=PB5 inside atmega32u4.v) so the {LED_USER, LED_DISK[0]} width mismatch below resolves
+// identically to the pre-rename connection instead of being re-guessed.
+wire [2:0] avr_rgb_out;
+
 atmega32u4 atmega32u4
 (
     .clk(clk_avr),
@@ -345,15 +350,19 @@ atmega32u4 atmega32u4
     .buttons(~(status[1] ? {joystick[5:4], joystick[1], joystick[0], joystick[2], joystick[3]} : joystick[5:0])),
     .joystick_analog(status[16] ? {~paddle[7],paddle[6:0]} : joystick_analog[7:0]),
     .status(|status[16:15]),
-    .RGB({LED_USER, LED_DISK[0]}),
-    .Buzzer1(Buzzer1),
-    .Buzzer2(Buzzer2),
-    .DC(oled_dc),
-    .spi_scl(oled_clk),
-    .spi_mosi(oled_data),
-    .uart_rx(USER_IN[0]),
-    .uart_tx(USER_OUT[1])
+    .PB6(avr_rgb_out[2]),
+    .PB7(avr_rgb_out[1]),
+    .PB5(avr_rgb_out[0]),
+    .PC6(Buzzer1),
+    .PC7(Buzzer2),
+    .PD4(oled_dc),
+    .PB1(oled_clk),
+    .PB2(oled_data),
+    .PD2(USER_IN[0]),
+    .PD3(USER_OUT[1])
 );
+
+assign {LED_USER, LED_DISK[0]} = avr_rgb_out;
 
 wire pixelValue, ce_pix;
 wire VSync, HSync, HBlank, VBlank;

--- a/files.qip
+++ b/files.qip
@@ -1,3 +1,4 @@
 set_global_assignment -name QIP_FILE rtl/avr/atmega.qip
 set_global_assignment -name VERILOG_FILE rtl/vgaHdmi.v
+set_global_assignment -name VERILOG_FILE rtl/arduboy_board.v
 set_global_assignment -name SYSTEMVERILOG_FILE Arduboy.sv

--- a/rtl/arduboy_board.v
+++ b/rtl/arduboy_board.v
@@ -1,0 +1,55 @@
+/*
+ * Real Arduboy board wiring: instantiates the generic atmega32u4 module and connects it exactly
+ * the way the real Arduboy PCB does. A different core reusing atmega32u4.v would replace this
+ * file with its own board wiring, not touch the chip module itself.
+ */
+
+`timescale 1ns / 1ps
+
+module arduboy_board
+(
+    input rst,
+    input clk,
+    input clk_pll,
+    output [13:0] pgm_addr,
+    input [15:0] pgm_data,
+    input [5:0] buttons,
+    input [7:0] joystick_analog,
+    input status,
+    output [2:0] RGB,
+    output Buzzer1, Buzzer2, DC, spi_scl, spi_mosi,
+    input uart_rx,
+    output uart_tx
+    );
+
+atmega32u4 atmega32u4
+(
+    .rst(rst),
+    .clk(clk),
+    .clk_pll(clk_pll),
+    .pgm_addr(pgm_addr),
+    .pgm_data(pgm_data),
+    .joystick_analog(joystick_analog),
+    .status(status),
+
+    // Buttons are wired to specific real pins on the real Arduboy PCB.
+    .PF6(buttons[0]), // BUTTON RIGHT
+    .PF5(buttons[1]), // BUTTON LEFT
+    .PF4(buttons[2]), // BUTTON DOWN
+    .PF7(buttons[3]), // BUTTON UP
+    .PE6(buttons[4]), // BUTTON A
+    .PB4(buttons[5]), // BUTTON B
+
+    .PB6(RGB[2]),
+    .PB7(RGB[1]),
+    .PB5(RGB[0]),
+    .PC6(Buzzer1),
+    .PC7(Buzzer2),
+    .PD4(DC),
+    .PB1(spi_scl),
+    .PB2(spi_mosi),
+    .PD2(uart_rx),
+    .PD3(uart_tx)
+    );
+
+endmodule

--- a/rtl/avr/README.md
+++ b/rtl/avr/README.md
@@ -1,0 +1,81 @@
+# ATmega32U4 module
+
+A reusable ATmega32U4 CPU + peripheral implementation with real datasheet pin names, meant to be
+dropped into other cores. Written for the Arduboy_MiSTer core originally; the Arduboy-specific
+wiring lives outside this directory, in `../arduboy_board.v`, which is a worked example of how a
+board instantiates this module — not part of the reusable bundle itself.
+
+Full derivation, with datasheet citations, is in `projects/arduboy-atmega-module/PROJECT.md` in
+the parent workspace. This file is the short version: what to connect and what to expect.
+
+## Taking this module into a new core
+
+Bring the whole directory, not individual files — `atmega32u4.v` has hard dependencies on every
+peripheral file below it. `atmega.qip` is the manifest; reference it as one `QIP_FILE` the same
+way `files.qip` does here, and it pulls in the complete implementation.
+
+## Ports
+
+Source of truth for every real pin identity: `Atmel-7766J-USB-ATmega16U4/32U4-Datasheet_04/2016`
+(ATmega16U4/32U4 datasheet), Figure 1-1 (p.3) and §10.3 alternate-function tables (pp.74-83).
+
+### Not real chip pins — FPGA-modeling artifacts
+
+| Port | Direction | What it actually is |
+|---|---|---|
+| `clk`, `clk_pll` | input | MiSTer supplies the clock directly. Real hardware has `XTAL1`/`XTAL2` or the internal 8MHz oscillator; neither is modeled. |
+| `rst` | input | Functionally corresponds to the real `RESET` pin, but modeled as a plain synchronous input, not the pin's real electrical behavior. |
+| `pgm_addr`, `pgm_data` | output / input | How this Verilog model loads flash contents. No real chip pin. |
+
+### Real chip pins, correctly named
+
+| Port | Direction | Real pin | Alternate function(s) | Status |
+|---|---|---|---|---|
+| `PB1` | output | SCK | Hardware SPI clock | Implemented — SPI master |
+| `PB2` | output | MOSI | Hardware SPI data out | Implemented — SPI master |
+| `PB4` | input | PCINT4/ADC11 | — | Digital GPIO only |
+| `PB5` | output | OC1A/PCINT5/ADC12 | Timer1 PWM, falls through to GPIO when disconnected | Implemented |
+| `PB6` | output | OC1B/PCINT6/ADC13 | Timer1 PWM, falls through to GPIO when disconnected | Implemented |
+| `PB7` | output | OC0A/OC1C/PCINT7/RTS | Timer0 PWM, falls through to GPIO when disconnected | Implemented |
+| `PC6` | output | OC3A | Timer3 PWM, falls through to GPIO when disconnected | Implemented |
+| `PC7` | output | ICP3/CLKO/OC4A | Timer4 PWM, falls through to GPIO when disconnected | Implemented |
+| `PD2` | input | RXD1 | Hardware USART1 receive | Implemented |
+| `PD3` | output | TXD1 | Hardware USART1 transmit | Implemented |
+| `PD4` | output | ICP1/ADC8 | — | Digital GPIO only; ICP1/ADC8 alternate functions not implemented |
+| `PE6` | input | INT6/AIN0 | — | Digital GPIO only |
+| `PF4`–`PF7` | input | ADC4-7/JTAG (TCK/TMS/TDO/TDI) | — | Digital GPIO only |
+
+**Not yet exposed at all:** `PB0` (SS), `PB3` (MISO — internal `spi_miso` wire exists but isn't a
+port; SPI receive is disabled by default, `USE_RX("FALSE")`), and every other real pin not listed
+above (`PD0`, `PD1`, `PD5`, `PD6`, `PD7`, `PF0`, `PF1`). Nothing wired to them yet, not because
+they're inaccurate — they were simply never needed by the Arduboy board so far.
+
+### Deliberately not real-pin-accurate — see Step 3, `projects/arduboy-atmega-module/PROJECT.md`
+
+| Port | Direction | Why it's still here |
+|---|---|---|
+| `joystick_analog` | input | Feeds `unstable_counters`, a fake-ADC stand-in wired directly into the CPU's internal bus (`data_addr`/`data_read`), not a boundary pin. Cleanly separating it means either implementing a real ADC peripheral or exposing internal CPU-bus signals as ports. Deferred as its own future project — not done in this rename/reorganization phase. |
+| `status` | input | Same as above — gates whether `joystick_analog` or floating-pin noise answers an ADC register read. |
+
+## What's real hardware but not implemented at all
+
+Confirmed by tracing every interrupt source in `atmega32u4.v` — these are permanently tied to `0`,
+never fire, regardless of what a game does:
+
+| Real peripheral | Evidence |
+|---|---|
+| USB 2.0 device controller | `int_usb_general = 0`, `int_usb_endpoint = 0`. No SIE/endpoint logic anywhere; no `D+`/`D-`/`VBUS`/`UCAP` ports. |
+| ADC (12-channel, 10-bit) | `int_adc = 0`. `unstable_counters.v` fakes register reads, not a real converter. |
+| TWI / I2C | `int_twi = 0`. No file implements it. |
+| Analog Comparator | `int_analog_comp = 0`. Nothing found. |
+| JTAG / on-chip debug | Nothing found. |
+
+**Present but disabled, unlike the rest:** the Watchdog Timer — `` `define WATCHDOG_CNT_WIDTH 0``
+(`atmega32u4.v`), with a real width (`27`) commented out right next to it. Most of the counter
+logic already exists.
+
+**Unverified either way:** SPI slave mode — a mode bit and status wire exist, but slave
+shift-register behavior was never traced end to end.
+
+The interrupt vector table is correctly sized for the real chip (`VECTOR_INT_TABLE_SIZE = 42`)
+even where the peripheral behind a given vector doesn't exist yet.

--- a/rtl/avr/atmega32u4.v
+++ b/rtl/avr/atmega32u4.v
@@ -99,10 +99,12 @@ module atmega32u4 # (
     input [5:0] buttons,
     input [7:0] joystick_analog,
     input status,
-    output [2:0] RGB,
-    output Buzzer1, Buzzer2, DC, spi_scl, spi_mosi,
-    input uart_rx,
-    output uart_tx
+    output PB5, PB6, PB7,
+    output PC6, PC7,
+    output PD4,
+    output PB1, PB2,
+    input PD2,
+    output PD3
     );
 
 wire core_clk = clk;
@@ -174,14 +176,14 @@ assign pe_in[6] = buttons[4]; // BUTTON A
 assign pb_in[4] = buttons[5]; // BUTTON B
 
 // RGB LED is common anode (ie. HIGH = OFF)
-assign RGB[2] = tim1_ocb_io_connect ? tim1_ocb : ~(pb_out[6]);
-assign RGB[1] = tim0_oca_io_connect ? ~tim0_oca : ~(pb_out[7]);
-assign RGB[0] = tim1_oca_io_connect ? tim1_oca : ~(pb_out[5]);
+assign PB6 = tim1_ocb_io_connect ? tim1_ocb : ~(pb_out[6]);
+assign PB7 = tim0_oca_io_connect ? ~tim0_oca : ~(pb_out[7]);
+assign PB5 = tim1_oca_io_connect ? tim1_oca : ~(pb_out[5]);
 
 // Fall through to GPIO when the timer output is disconnected, same as the RGB LED pins above.
-assign Buzzer1 = tim3_oca_io_connect ? tim3_oca : pc_out[6];
-assign Buzzer2 = tim4_ocap_io_connect ? tim4_oca : pc_out[7];
-assign DC = pd_out[4];
+assign PC6 = tim3_oca_io_connect ? tim3_oca : pc_out[6];
+assign PC7 = tim4_ocap_io_connect ? tim4_oca : pc_out[7];
+assign PD4 = pd_out[4];
 
 /* Interrupt wires */
 wire ram_sel = |data_addr[`BUS_ADDR_DATA_LEN-1:8];
@@ -511,9 +513,9 @@ atmega_spi_m # (
     .io_connect(spi_io_connect),
     .io_conn_slave(io_conn_slave),
 
-    .scl(spi_scl),
+    .scl(PB1),
     .miso(spi_miso),
-    .mosi(spi_mosi)
+    .mosi(PB2)
     );
 end
 else
@@ -555,8 +557,8 @@ atmega_uart # (
     .udre_int(int_usart1_udre),
     .udre_int_rst(int_usart1_udre_rst),
 
-    .rx(uart_rx),
-    .tx(uart_tx),
+    .rx(PD2),
+    .tx(PD3),
     .tx_connect(uart_tx_io_connect)
     );
 end

--- a/rtl/avr/atmega32u4.v
+++ b/rtl/avr/atmega32u4.v
@@ -96,9 +96,9 @@ module atmega32u4 # (
     input clk_pll,
     output [`ROM_ADDR_WIDTH-1:0] pgm_addr,
     input [15:0] pgm_data,
-    input [5:0] buttons,
     input [7:0] joystick_analog,
     input status,
+    input PF4, PF5, PF6, PF7, PE6, PB4,
     output PB5, PB6, PB7,
     output PC6, PC7,
     output PD4,
@@ -168,12 +168,12 @@ wire usb_ck_out;
 wire tim_ck_out;
 /* !IO ALTERNATIVE FUNCTION */
 
-assign pf_in[6] = buttons[0]; // BUTTON RIGHT
-assign pf_in[5] = buttons[1]; // BUTTON LEFT
-assign pf_in[4] = buttons[2]; // BUTTON DOWN
-assign pf_in[7] = buttons[3]; // BUTTON UP
-assign pe_in[6] = buttons[4]; // BUTTON A
-assign pb_in[4] = buttons[5]; // BUTTON B
+assign pf_in[6] = PF6;
+assign pf_in[5] = PF5;
+assign pf_in[4] = PF4;
+assign pf_in[7] = PF7;
+assign pe_in[6] = PE6;
+assign pb_in[4] = PB4;
 
 // RGB LED is common anode (ie. HIGH = OFF)
 assign PB6 = tim1_ocb_io_connect ? tim1_ocb : ~(pb_out[6]);


### PR DESCRIPTION
Per suggestion in earlier PR:

First step in making reusable AVR module for ATmega family of Chips.

- `rtl/avr/atmega32u4.v` — port list renamed to real ATmega16U4/32U4 pins (`PB1`, `PC6`, `PD4`,
  etc.), sourced from the datasheet (Figure 1-1 p.3, §10.3 alt-function tables pp.74-83).
  `rtl/avr/README.md` documents the full pin mapping and what's implemented vs. stubbed.
- `rtl/arduboy_board.v` — new, instantiates `atmega32u4` and wires it to the real Arduboy PCB
  pinout. Only Arduboy-specific piece left; `Arduboy.sv` instantiates this instead of
  `atmega32u4` directly.

Confirmed no behavioral change: the pin-rename and board-split steps compiled to byte-identical
bitstreams, and Verilator lint output is unchanged before/after each step. Hardware-tested
across every category in a large sorted game collection (Action/Adventure/Demo/Misc/Tabletop/
Strategy/Sports/Skill) plus targeted regression runs after each step — no regressions.