### PR TITLE
 Core fixes - cycle timing, interrupt-dispatch race, RAM reset-clear bug

### DIFF
--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -207,6 +207,43 @@ reg [4:0]rs1a;
 reg [4:0]rs2a;
 reg [4:0]rda;
 
+// OUT 1-cycle write-back stage, 2026-08-11 -- see projects/mega-regfile-timing-fix/PROJECT.md and
+// projects/uzebox/PROJECT.md for the full investigation. rs1a/reg_rs1 for a same-STEP0-read of OUT
+// aren't settled until a full cycle after decode (cross-module NBA propagation through mega_regs),
+// so OUT's SREG/SP/data-bus side effects are deferred, decoupled from state_cnt.
+//
+// out_retire_pending is a LEVEL signal, not a one-shot pulse: it stays 1 for as long as a deferred
+// write hasn't yet found a free bus cycle (see bus_busy_this_cycle above, and the "Set
+// out_retire_pending" block below for the full state machine). At most one retirement is ever
+// pending at a time -- a second OUT cannot decode onto the fast path while one is still waiting,
+// it stalls instead (see the PC/state_cnt arms below) -- so out_retire_instr/out_rs1a are never at
+// risk of being overwritten before the pending write they belong to actually fires.
+//
+// out_rs1a is a DEDICATED, non-shared copy of rs1a's own default-assignment rule
+// (out_rs1a <= pgm_data_registered[8:4], set once at OUT's own decode), read via mega_regs' third
+// port (rs3a/rs3). This is deliberately NOT "capture reg_rs1 into a register one edge later" --
+// that was tried first and is a real, confirmed-by-simulation bug: reg_rs1 is shared with
+// whatever instruction is CURRENTLY decoding (rs1a is overwritten every cycle by the default
+// assignment), so by the time a retiring OUT would read it, rs1a/reg_rs1 already belong to the
+// NEXT instruction, not this one. out_rs1a is never touched by any other instruction, so it
+// settles after exactly one cycle (same physical settling time as rs1/rs1a) and then simply
+// stays correct for as long as it's needed, with no capture-timing window to get wrong.
+reg out_retire_pending;
+reg [15:0]out_retire_instr;
+reg [4:0]out_rs1a;
+wire [15:0]out_reg_rs1;
+
+// Read-after-write hazard holding register, 2026-08-11 -- see the pgm_data_registered update
+// site below for why. A naive "freeze PC, let it re-fetch the same instruction" was tried first
+// and is wrong: PC runs two pipeline stages ahead of pgm_data_registered (this engine's own
+// fetch/decode structure, established earlier in this investigation), so freezing PC at its
+// CURRENT value and re-fetching lands on the instruction AFTER the blocked one, silently
+// skipping it -- confirmed by simulation (fn32's r12 read never happened at all). Capturing the
+// actual blocked opcode directly and releasing it later, instead of re-deriving it through the
+// ROM a second time, sidesteps the pipeline-lag arithmetic entirely.
+reg holding_instr;
+reg [15:0]held_instr;
+
 reg [15:0]alu_rs1;
 reg [15:0]alu_rs2;
 wire [15:0]alu_rd;
@@ -249,6 +286,72 @@ wire [int_bus_size - 1 : 0]current_int_vect_request;
 reg [int_bus_size - 1 : 0]current_int_vect_registered;
 wire int_request;
 reg int_registered;
+
+// Second design, 2026-08-11 -- the first design (peek at pgm_data_int for the NEXT instruction,
+// at OUT's own decode edge, to decide fast-vs-fallback up front) is GONE. It relied on
+// pgm_data_int being settled to the next instruction's opcode within the same edge OUT itself
+// decodes on, and simulation proved that's false: pgm_data_int, read at that exact edge, still
+// reflects the CURRENT instruction (pgm_data hasn't had its own NBA land yet, one whole edge
+// behind where the peek needs it) -- confirmed by direct trace (fn32/fn52 regressed to a single
+// residual byte mismatch each from exactly this). No amount of registering pgm_data_int earlier
+// fixes it either, per the "no free lookahead cycle" finding elsewhere in this project.
+//
+// This design instead never looks ahead at all. OUT unconditionally takes the fast path (defers
+// its write to a PENDING retirement, below) and the deferred write simply waits, cycle by cycle,
+// for the data bus to be free -- checked using ONLY the CURRENT cycle's state_cnt/pgm_data_registered,
+// which (unlike pgm_data_int) are read directly within the same block that just wrote them and are
+// confirmed reliable that way (out_retire_instr <= pgm_data_registered already relies on exactly
+// this). bus_busy_user mirrors every STEP where the "Set data_addr"/"Set data_out"/
+// "Set data_write"/"Set data_read" blocks below already touch the bus for a non-OUT instruction.
+//
+// A FUNCTION, not a separate always@*/wire: a function call is evaluated inline, as part of
+// whichever procedural statement calls it -- not a separate triggered process -- so it sees
+// pgm_data_registered's freshly-blocking-updated value the same way any other statement further
+// down in this same clocked block does. A plain `wire`/`always@*` reading pgm_data_registered
+// from outside this exact procedural flow was empirically proven unreliable twice in this file
+// already (OUT_TARGETS_SREG's own history, and this same bus-busy check's first version) -- both
+// read pgm_data_registered one edge late.
+function bus_busy_user;
+	input [1:0] chk_state;
+	input [15:0] chk_instr;
+	begin
+		casex({chk_state, CORE_TYPE, chk_instr})
+			{`STEP0, `INSTRUCTION_RCALL}, {`STEP1, `INSTRUCTION_RCALL},
+			{`STEP0, `INSTRUCTION_CALL},  {`STEP1, `INSTRUCTION_CALL},
+			{`STEP0, `INSTRUCTION_ICALL}, {`STEP1, `INSTRUCTION_ICALL},
+			{`STEP0, `INSTRUCTION_RET},   {`STEP1, `INSTRUCTION_RET},   {`STEP2, `INSTRUCTION_RET},
+			{`STEP0, `INSTRUCTION_RETI},  {`STEP1, `INSTRUCTION_RETI},  {`STEP2, `INSTRUCTION_RETI},
+			{`STEP0, `INSTRUCTION_POP},   {`STEP1, `INSTRUCTION_POP},
+			{`STEP0, `INSTRUCTION_IN},
+			{`STEP0, `INSTRUCTION_CBI_SBI},   {`STEP1, `INSTRUCTION_CBI_SBI},
+			{`STEP0, `INSTRUCTION_SBIC_SBIS}, {`STEP1, `INSTRUCTION_SBIC_SBIS}: bus_busy_user = 1'b1;
+			default: bus_busy_user = 1'b0;
+		endcase
+	end
+endfunction
+// Both plain `reg`s, blocking-assigned early in the main clocked block (right after
+// pgm_data_registered's own update) rather than declared as wires/continuous assignments here --
+// see that assignment site for why.
+reg bus_busy_this_cycle;
+reg out_retire_fire;
+
+// A retiring OUT writes SREG one cycle late relative to its own decode (same reasoning as the
+// data-bus hazard above) -- but unlike the data bus, SREG is read implicitly by nearly the whole
+// ISA: every ALU instruction's flag computation and every conditional branch reads sreg_out, which
+// is combinationally derived from SREG itself (mega_alu_inst's .sreg_in(SREG) port below). That is
+// not a narrow, enumerable hazard list the way the data bus is -- so OUT targeting SREG (I/O 0x3F)
+// always falls back to the original 2-cycle path, unconditionally. Confirmed necessary, not
+// theoretical: caught by fn43/44/45/60-67/t32u4_sp regressing when this was missing.
+//
+// Deliberately NOT a `wire` depending on pgm_data_registered: pgm_data_registered is written by
+// BLOCKING assignment inside this same clocked always block (see "pgm_data_registered = ..." far
+// above), and a `wire` reading it from outside that block's own procedural flow was empirically
+// shown (via inline $display, since first-principles reasoning about this exact class of bug has
+// twice been wrong this session) to read pgm_data_registered's value from ONE EDGE EARLIER, not
+// the freshly-decoded one -- same delta-cycle-lag class as everything else in this investigation.
+// Instead this is inlined directly with pgm_data_registered at each of the three use sites below,
+// matching how out_retire_instr <= pgm_data_registered already reads it correctly.
+`define OUT_TARGETS_SREG ({pgm_data_registered[10:9],pgm_data_registered[3:0]} == 6'h3F)
 
 int_encoder # (
 	.VECTOR_INT_TABLE_SIZE(VECTOR_INT_TABLE_SIZE)
@@ -493,8 +596,67 @@ begin
 				cnt_rst = 1'b0;
 				pgm_data_registered = 16'h0000;
 			end
+			else if(holding_instr)
+			begin
+				// A real instruction is being held (see declaration above) because it collided
+				// with a still-pending OUT retirement when first fetched. Re-check the SAME
+				// conflict against the HELD opcode (not a fresh re-fetch -- that's exactly the
+				// pipeline-lag trap this design avoids) every cycle until it's safe.
+				if(out_retire_pending & bus_busy_user(`STEP0, held_instr))
+				begin
+					// Still blocked: keep presenting NOP (suppresses side effects, same as the
+					// initial detection below) and keep PC frozen -- holding_instr itself is
+					// the "retry" state, no PC re-fetch involved.
+					pgm_data_registered = 16'h0000;
+					PC <= PC;
+				end
+				else
+				begin
+					// Clear now: release the held instruction for real execution this cycle.
+					// PC is deliberately left alone here -- it was frozen for the entire hold
+					// and already points at the instruction AFTER this one, so the normal
+					// fetch pipeline resumes correctly on its own from here.
+					pgm_data_registered = held_instr;
+					holding_instr <= 1'b0;
+				end
+			end
 			else if(&{state_cnt == `STEP0, ~skip_next_clock})
+			begin
 				pgm_data_registered = pgm_data_int;
+				// Read-after-write hazard: a still-pending OUT retirement (out_retire_pending)
+				// writes an I/O address one or more cycles after its own decode (see
+				// out_retire_pending's declaration above). If the instruction that just latched
+				// is itself an I/O-space reader/writer (IN/CBI/SBI/SBIC/SBIS -- the same address
+				// space OUT's retirement targets), letting it proceed now would read/write
+				// stale data, since the pending write hasn't landed yet. Confirmed as a REAL bug,
+				// not theoretical: fn32/fn52 read back a just-written I/O port before a retirement
+				// stuck behind other bus traffic had actually fired, seeing the old value.
+				//
+				// Captures the real opcode into held_instr and starts holding (see that reg's
+				// declaration for why a naive PC-freeze-and-re-fetch is wrong). Reverts
+				// pgm_data_registered to NOP (0x0000, the same "do nothing" value cnt_rst uses
+				// above) so every "Set X" block below naturally no-ops this cycle, and freezes
+				// PC so it doesn't run further ahead while the hold is in effect.
+				if(out_retire_pending & bus_busy_user(`STEP0, pgm_data_registered))
+				begin
+					held_instr <= pgm_data_registered;
+					holding_instr <= 1'b1;
+					pgm_data_registered = 16'h0000;
+					PC <= PC;
+				end
+			end
+			// Computed here (blocking, right after pgm_data_registered's own update) rather
+			// than as a separate always@*/wire: a separate process reading pgm_data_registered
+			// was empirically proven unreliable earlier in this file (see OUT_TARGETS_SREG's own
+			// history) and again here (bus_busy_this_cycle_r's first version had the identical
+			// bug) -- pgm_data_registered is written by BLOCKING assignment inside THIS block,
+			// and anything outside this exact procedural flow sees it one edge late. Blocking
+			// assignment here, immediately after pgm_data_registered's own update and before any
+			// of the "Set X" blocks that consume it, makes every later statement in this same
+			// pass see the correct, freshly-decoded value -- the same reason pgm_data_registered
+			// itself is safe to read directly further down in this block.
+			bus_busy_this_cycle = bus_busy_user(state_cnt, pgm_data_registered) | int_registered;
+			out_retire_fire = out_retire_pending & ~bus_busy_this_cycle;
 			unlock_int_registered_step_2 <= 1'b0;
 			rs2a <= {pgm_data_registered[9], pgm_data_registered[3:0]};
 			rs1a <= pgm_data_registered[8:4];
@@ -540,11 +702,21 @@ begin
 					end
 					{1'b1, `STEP1, `INSTRUCTION_OUT}:
 					begin
+						// OUT_TARGETS_SREG path only (that's the only way state_cnt reaches STEP1
+						// for OUT now) -- mutually exclusive with the out_retire_fire block below.
 						case({pgm_data_registered[10:9],pgm_data_registered[3:0]})
 							6'h3F: SREG <= reg_rs1;
 						endcase
 					end
 				endcase
+				// OUT-retire write-back (SREG): fires once out_retire_pending's write is free to
+				// go -- see out_retire_pending's declaration above for why.
+				if(out_retire_fire)
+				begin
+					case({out_retire_instr[10:9],out_retire_instr[3:0]})
+						6'h3F: SREG <= out_reg_rs1;
+					endcase
+				end
 	/* Set "SP" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 				{1'b1, `STEP0, `INSTRUCTION_RCALL},
@@ -572,9 +744,10 @@ begin
 				end
 				{1'b1, `STEP1, `INSTRUCTION_OUT}:
 				begin
+					// Hazard-fallback path only -- see the matching comment in "Set SREG" above.
 					case({pgm_data_registered[10:9],pgm_data_registered[3:0]})
 						6'h3D: SP[7:0] <= reg_rs1;
-						6'h3E: 
+						6'h3E:
 						begin
 							if(RAM_ADDR_WIDTH > 8)
 								SP[RAM_ADDR_WIDTH - 1:8] <= reg_rs1;
@@ -582,6 +755,18 @@ begin
 					endcase
 				end
 				endcase
+				// OUT-retire write-back (SP): one cycle after decode, decoupled from state_cnt.
+				if(out_retire_fire)
+				begin
+					case({out_retire_instr[10:9],out_retire_instr[3:0]})
+						6'h3D: SP[7:0] <= out_reg_rs1;
+						6'h3E:
+						begin
+							if(RAM_ADDR_WIDTH > 8)
+								SP[RAM_ADDR_WIDTH - 1:8] <= out_reg_rs1;
+						end
+					endcase
+				end
 	/* Set "rs1a" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_MULS}: rs1a[4] <= 1'b1;
@@ -828,7 +1013,7 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP2, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
-					{1'b1, `STEP1, `INSTRUCTION_IN},
+					{1'b1, `STEP0, `INSTRUCTION_IN}, // IN-only 1-cycle fix (does not read reg_rs1, only writes via rda/reg_rdw -- safe independent of OUT, which stays at its original 2-cycle timing -- see projects/mega-regfile-timing-fix/PROJECT.md)
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R_P},
@@ -961,14 +1146,17 @@ begin
 							data_addr_int <= reg_rs2 - 1;
 					end
 					{1'b1, `STEP2, `INSTRUCTION_ST_XN}: data_addr_int <= data_addr_int;
-					{1'b1, `STEP1, `INSTRUCTION_OUT},
 					{1'b1, `STEP0, `INSTRUCTION_IN},
 					{1'b1, `STEP1, `INSTRUCTION_IN}: data_addr_int <= {pgm_data_registered[10:9],pgm_data_registered[3:0]} + 'h20;
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP1, `INSTRUCTION_SBIC_SBIS}: data_addr_int <= pgm_data_registered[7:3] + 'h20;
+					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_addr_int <= {pgm_data_registered[10:9],pgm_data_registered[3:0]} + 'h20;
 				endcase
+				// OUT-retire write-back (I/O address): one cycle after decode.
+				if(out_retire_fire)
+					data_addr_int <= {out_retire_instr[10:9],out_retire_instr[3:0]} + 'h20;
 	/* Set "data_out" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_RCALL}: data_out_int <= PC;
@@ -991,7 +1179,6 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_ST_X},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP2, `INSTRUCTION_ST_XN}: data_out_int <= reg_rs1;
-					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_out_int = reg_rs1;
 					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI}:
 					begin
 						if(pgm_data_registered[9])
@@ -999,7 +1186,11 @@ begin
 						else
 							data_out_int = data_in & ~(2 ** pgm_data_registered[2:0]);
 					end
+					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_out_int = reg_rs1;
 				endcase
+				// OUT-retire write-back (data value): one cycle after decode.
+				if(out_retire_fire)
+					data_out_int = out_reg_rs1;
 	/* Set "data_write" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_RCALL},
@@ -1017,9 +1208,12 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP2, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP1, `INSTRUCTION_STS},
-					{1'b1, `STEP1, `INSTRUCTION_OUT},
-					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI}: data_write_int <= 1'b1;
+					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI},
+					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_write_int <= 1'b1;
 				endcase
+				// OUT-retire write-back (write strobe): one cycle after decode.
+				if(out_retire_fire)
+					data_write_int <= 1'b1;
 	/* Set "data_read" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP1, `INSTRUCTION_RET},
@@ -1035,7 +1229,7 @@ begin
 					{1'b1, `STEP2, `INSTRUCTION_LD_XP},
 					{1'b1, `STEP2, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP2, `INSTRUCTION_LDS},
-					{1'b1, `STEP1, `INSTRUCTION_IN},
+					{1'b1, `STEP0, `INSTRUCTION_IN}, // IN-only 1-cycle fix
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP1, `INSTRUCTION_SBIC_SBIS}: data_read_int <= 1'b1;
@@ -1068,13 +1262,20 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP0, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
-					{1'b1, `STEP0, `INSTRUCTION_OUT},
-					{1'b1, `STEP0, `INSTRUCTION_IN},
+					// OUT removed from this unconditional list -- now conditional, see below.
+					// IN removed from this list -- IN-only 1-cycle fix
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_ELPM}: state_cnt <= `STEP1;
+					// OUT stays STEP0 (genuinely 1-cycle) except OUT_TARGETS_SREG, which always
+					// falls back to the original, proven 2-cycle STEP0->STEP1 path. A stalled OUT
+					// (blocked behind a still-pending retirement) ALSO stays at STEP0 -- that's
+					// not a bug, it's the mechanism: pgm_data_registered/rs1a simply re-latch the
+					// same OUT instruction next cycle (harmless, PC hasn't moved) and the
+					// "Set out_retire_pending" block above re-checks whether it can arm yet.
+					{1'b1, `STEP0, `INSTRUCTION_OUT}: if(`OUT_TARGETS_SREG) state_cnt <= `STEP1;
 	/*************************************************************/
 					{1'b1, `STEP1, `INSTRUCTION_RET},
 					{1'b1, `STEP1, `INSTRUCTION_RETI}: state_cnt <= `STEP2;
@@ -1132,6 +1333,30 @@ begin
 					{1'b1, `STEP2, `INSTRUCTION_CPSE},
 					{1'b1, `STEP2, `INSTRUCTION_SBRC_SBRS},
 					{1'b1, `STEP2, `INSTRUCTION_SBIC_SBIS}: state_cnt <= `STEP3;
+				endcase
+	/* Set "out_retire_pending" */ /*************************************************************/
+				// A pending write fires and clears whenever the bus is free, REGARDLESS of what's
+				// decoding this same cycle -- evaluated first so a new OUT arming below (same
+				// cycle, bus free) can immediately re-arm it (last NBA write wins, see the
+				// declaration comment for why exactly one retirement is ever in flight).
+				if(out_retire_fire)
+					out_retire_pending <= 1'b0;
+				// Arms a NEW pending write only when safe: not SREG (unconditionally the old
+				// STEP1 mechanism, unrelated to this) and not stalled behind an existing pending
+				// write that isn't clearing this cycle. out_rs1a <= pgm_data_registered[8:4]
+				// mirrors rs1a's own default assignment exactly (same source field, same
+				// timing), but into the dedicated, non-shared register described above -- see
+				// its declaration for why a shared-rs1a capture was tried first and is wrong.
+				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
+					{1'b1, `STEP0, `INSTRUCTION_OUT}:
+					begin
+						if(~`OUT_TARGETS_SREG & ~(out_retire_pending & bus_busy_this_cycle))
+						begin
+							out_retire_pending <= 1'b1;
+							out_retire_instr <= pgm_data_registered;
+							out_rs1a <= pgm_data_registered[8:4];
+						end
+					end
 				endcase
 	/* Set "PC_TMP_H" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
@@ -1193,8 +1418,8 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
-					{1'b1, `STEP0, `INSTRUCTION_OUT},
-					{1'b1, `STEP0, `INSTRUCTION_IN},
+					// OUT removed from this unconditional freeze list -- now conditional, see below.
+					// IN removed from this PC-freeze list too -- IN-only 1-cycle fix
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R},
@@ -1203,6 +1428,11 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_ELPM},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_ELPM}: PC <= PC;
+					// OUT freezes PC for OUT_TARGETS_SREG's old mechanism, or while genuinely
+					// stalled (a retirement is pending and the bus is busy this cycle -- see
+					// "Set out_retire_pending" above); otherwise PC advances normally
+					// (PC_PLUS_ONE, set earlier) for genuine 1-cycle throughput.
+					{1'b1, `STEP0, `INSTRUCTION_OUT}: if(`OUT_TARGETS_SREG | (out_retire_pending & bus_busy_this_cycle)) PC <= PC;
 				endcase
 			end
 		end
@@ -1237,7 +1467,9 @@ mega_regs #(
 	.rda(rda),
 	.rd(reg_rd),
 	.rdw(reg_rdw),
-	.rdm(reg_rdm)
+	.rdm(reg_rdm),
+	.rs3a(out_rs1a),
+	.rs3(out_reg_rs1)
 );
 
 watchdog # (

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -442,7 +442,28 @@ begin
 					// same hazard check a real CALL already gets, and simply don't dispatch yet on
 					// a colliding cycle. The interrupt stays pending (int_rst doesn't fire) and
 					// this case is re-checked next cycle, same as any other stalled dispatch.
-					if(~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)))
+					//
+					// Second, distinct gap found chasing the Round 24 choppy-audio investigation
+					// (projects/mega-regfile-timing-fix/PROJECT.md, Round 24 continuation): the
+					// check above only protects against a NEW retirement colliding with THIS
+					// synthetic word. It says nothing about holding_instr already being active from
+					// an EARLIER, completely unrelated collision (a real, ROM-fetched instruction
+					// that got captured and is still waiting to release -- see the "Set
+					// holding_instr"/"holding_instr" blocks below). On the exact cycle an old hold
+					// releases, the clocked block's if/else-if chain (cnt_rst -> holding_instr ->
+					// this synthetic-word latch) gives the stale held_instr priority over
+					// pgm_data_int unconditionally -- confirmed directly in simulation: int_registered
+					// and int_rst fire here exactly as designed (the peripheral's pending flag gets
+					// cleared, so it never asks again), but pgm_data_registered ends up latching
+					// held_instr instead of pgm_data_int, so the CPU never actually redirects to the
+					// vector -- the interrupt is silently dropped, not delayed. On real audio code
+					// this manifests as one fully missed tone-timer tick (a doubled gap in the
+					// output waveform) every time the two coincide. Fix: don't dispatch on a cycle
+					// where holding_instr is active, for the same reason as the retirement check
+					// above -- pgm_data_registered is guaranteed to go to holding_instr's release
+					// path this cycle regardless, so presenting the synthetic word here would just
+					// be silently discarded. Stays pending and retries next cycle, same pattern.
+					if(~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)) & ~holding_instr)
 					begin
 						pgm_data_int = 16'b1001010000001110;
 						int_registered = 1'b1;
@@ -469,8 +490,10 @@ begin
 		begin
 			// Gated the same way as the STEP0 case above, and for the same reason: only latch once
 			// the injection itself is actually going to fire this cycle, so the two stay in lockstep.
+			// ~holding_instr added alongside the retirement check for the same reason it was added
+			// above -- see that comment for the full mechanism.
 			if(({unlock_int_registered_step_2, int_request, sreg_out[`XMEGA_FLAG_I], state_cnt} == {3'b011, `STEP0})
-				& ~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)))
+				& ~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)) & ~holding_instr)
 				current_int_vect_registered <= current_int_vect_request;
 		end
 	end

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -428,41 +428,11 @@ begin
 				begin
 					//if(~|last_state)
 					//begin
-					// Round 21 fix (see projects/mega-regfile-timing-fix/PROJECT.md) -- this STEP0
-					// case manufactures a synthetic CALL opcode (0x940E) and pushes it through the
-					// same STEP0/STEP1 path a real, ROM-fetched CALL uses, including CALL's own
-					// stack push (drives the same data_addr_int/data_out_int/data_write_int bus a
-					// pending OUT retirement, out_retire_pending, also needs to fire on). A real
-					// CALL colliding with a pending retirement is already protected by
-					// bus_busy_user() below; this one-cycle synthetic word is NOT, because it never
-					// goes through holding_instr's capture/retry path, and routing it through that
-					// path instead corrupted the CPU (Round 21 root cause -- holding_instr cannot
-					// tell this word apart from a real CALL and mishandles its own state on
-					// release). Fix: give interrupt entry its own, self-contained wait -- reuse the
-					// same hazard check a real CALL already gets, and simply don't dispatch yet on
-					// a colliding cycle. The interrupt stays pending (int_rst doesn't fire) and
-					// this case is re-checked next cycle, same as any other stalled dispatch.
-					//
-					// Second, distinct gap found chasing the Round 24 choppy-audio investigation
-					// (projects/mega-regfile-timing-fix/PROJECT.md, Round 24 continuation): the
-					// check above only protects against a NEW retirement colliding with THIS
-					// synthetic word. It says nothing about holding_instr already being active from
-					// an EARLIER, completely unrelated collision (a real, ROM-fetched instruction
-					// that got captured and is still waiting to release -- see the "Set
-					// holding_instr"/"holding_instr" blocks below). On the exact cycle an old hold
-					// releases, the clocked block's if/else-if chain (cnt_rst -> holding_instr ->
-					// this synthetic-word latch) gives the stale held_instr priority over
-					// pgm_data_int unconditionally -- confirmed directly in simulation: int_registered
-					// and int_rst fire here exactly as designed (the peripheral's pending flag gets
-					// cleared, so it never asks again), but pgm_data_registered ends up latching
-					// held_instr instead of pgm_data_int, so the CPU never actually redirects to the
-					// vector -- the interrupt is silently dropped, not delayed. On real audio code
-					// this manifests as one fully missed tone-timer tick (a doubled gap in the
-					// output waveform) every time the two coincide. Fix: don't dispatch on a cycle
-					// where holding_instr is active, for the same reason as the retirement check
-					// above -- pgm_data_registered is guaranteed to go to holding_instr's release
-					// path this cycle regardless, so presenting the synthetic word here would just
-					// be silently discarded. Stays pending and retries next cycle, same pattern.
+					// Synthetic CALL (0x940E) shares CALL's STEP0/STEP1 datapath, so it needs the
+					// same out_retire_pending/bus_busy_user() hazard check. It must also wait out
+					// holding_instr: a releasing hold has unconditional priority below, so
+					// dispatching here would fire int_registered/int_rst but never latch the
+					// synthetic word -- silently dropping the interrupt instead of stalling it.
 					if(~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)) & ~holding_instr)
 					begin
 						pgm_data_int = 16'b1001010000001110;
@@ -488,10 +458,7 @@ begin
 	begin
 		if(&{~skip_next_clock, ~cnt_rst, (USE_HALT != "TRUE" | ~halt_int | state_cnt != `STEP0)})
 		begin
-			// Gated the same way as the STEP0 case above, and for the same reason: only latch once
-			// the injection itself is actually going to fire this cycle, so the two stay in lockstep.
-			// ~holding_instr added alongside the retirement check for the same reason it was added
-			// above -- see that comment for the full mechanism.
+			// Same guard as the STEP0 dispatch case above, kept in lockstep.
 			if(({unlock_int_registered_step_2, int_request, sreg_out[`XMEGA_FLAG_I], state_cnt} == {3'b011, `STEP0})
 				& ~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)) & ~holding_instr)
 				current_int_vect_registered <= current_int_vect_request;

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -424,16 +424,33 @@ begin
 		if(&{~skip_next_clock, ~cnt_rst, (USE_HALT != "TRUE" | ~halt_int | state_cnt != `STEP0)})
 		begin
 			case({unlock_int_registered_step_2, int_request, sreg_out[`XMEGA_FLAG_I], state_cnt})
-				{3'b011, `STEP0}: 
+				{3'b011, `STEP0}:
 				begin
 					//if(~|last_state)
 					//begin
-					pgm_data_int = 16'b1001010000001110;
-					int_registered = 1'b1;
-					int_rst = 1'b1 << (current_int_vect_request - 1);
+					// Round 21 fix (see projects/mega-regfile-timing-fix/PROJECT.md) -- this STEP0
+					// case manufactures a synthetic CALL opcode (0x940E) and pushes it through the
+					// same STEP0/STEP1 path a real, ROM-fetched CALL uses, including CALL's own
+					// stack push (drives the same data_addr_int/data_out_int/data_write_int bus a
+					// pending OUT retirement, out_retire_pending, also needs to fire on). A real
+					// CALL colliding with a pending retirement is already protected by
+					// bus_busy_user() below; this one-cycle synthetic word is NOT, because it never
+					// goes through holding_instr's capture/retry path, and routing it through that
+					// path instead corrupted the CPU (Round 21 root cause -- holding_instr cannot
+					// tell this word apart from a real CALL and mishandles its own state on
+					// release). Fix: give interrupt entry its own, self-contained wait -- reuse the
+					// same hazard check a real CALL already gets, and simply don't dispatch yet on
+					// a colliding cycle. The interrupt stays pending (int_rst doesn't fire) and
+					// this case is re-checked next cycle, same as any other stalled dispatch.
+					if(~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)))
+					begin
+						pgm_data_int = 16'b1001010000001110;
+						int_registered = 1'b1;
+						int_rst = 1'b1 << (current_int_vect_request - 1);
+					end
 					//end
 				end
-				{3'b111, `STEP1}: 
+				{3'b111, `STEP1}:
 				begin
 					pgm_data_int = {current_int_vect_registered, 1'b0};
 					int_registered = 1'b1;
@@ -450,7 +467,10 @@ begin
 	begin
 		if(&{~skip_next_clock, ~cnt_rst, (USE_HALT != "TRUE" | ~halt_int | state_cnt != `STEP0)})
 		begin
-			if({unlock_int_registered_step_2, int_request, sreg_out[`XMEGA_FLAG_I], state_cnt} == {3'b011, `STEP0})
+			// Gated the same way as the STEP0 case above, and for the same reason: only latch once
+			// the injection itself is actually going to fire this cycle, so the two stay in lockstep.
+			if(({unlock_int_registered_step_2, int_request, sreg_out[`XMEGA_FLAG_I], state_cnt} == {3'b011, `STEP0})
+				& ~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)))
 				current_int_vect_registered <= current_int_vect_request;
 		end
 	end
@@ -586,6 +606,16 @@ initial begin
 	data_out_int = 8'h00;
 	PC_TMP_H = 8'h00;
 	int_rst = 1'b0;
+	// OUT 1-cycle retirement/hazard state, 2026-08-12 -- see
+	// projects/mega-regfile-timing-fix/PROJECT.md Round 7/Round 9. Without this, Icarus starts
+	// these as X (undriven reg) and real Quartus-synthesized silicon would power up to some
+	// unspecified concrete value, since neither simulator nor synthesizer has a defined value to
+	// fall back on without an explicit initial value.
+	out_retire_pending = 1'b0;
+	out_retire_instr = 16'h0000;
+	out_rs1a = 5'h00;
+	held_instr = 16'h0000;
+	holding_instr = 1'b0;
 end
 
 reg halt_ack_n;
@@ -606,6 +636,15 @@ begin
 		//io_addr_int <= 6'h00;
 		//io_out_int = 8'h00;
 		//PC_TMP_H <= 8'h00;
+		// OUT 1-cycle retirement/hazard state, 2026-08-12 -- see
+		// projects/mega-regfile-timing-fix/PROJECT.md Round 7/Round 9. Unlike SP/SREG/etc above,
+		// these two are live control state, not data a fresh boot immediately overwrites -- if a
+		// retirement or hold is stuck when a soft reset happens, nothing in software can ever
+		// unstick it, so core_rst (unlike a cold power-up) has to actively clear it. out_retire_
+		// instr/out_rs1a/held_instr don't need clearing here: like SP/data_out_int above, they're
+		// only ever read while one of these two flags is set.
+		out_retire_pending <= 1'b0;
+		holding_instr <= 1'b0;
 	end
 	else
 	begin

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -293,12 +293,11 @@ function bus_busy_user;
 			{`STEP0, `INSTRUCTION_IN},
 			{`STEP0, `INSTRUCTION_CBI_SBI},   {`STEP1, `INSTRUCTION_CBI_SBI},
 			{`STEP0, `INSTRUCTION_SBIC_SBIS}, {`STEP1, `INSTRUCTION_SBIC_SBIS},
-			// LD/ST/PUSH family: STEP1/STEP2 entries are mechanically derived from every real
-			// site each instruction touches the shared bus at, and are the load-bearing hazard
-			// coverage against a same-cycle collision with a pending OUT retirement. No STEP0
-			// entry -- pre-emptive STEP0 coverage was tried and removed: it held incoming
-			// instructions unnecessarily often, costing real stall cycles hardware never pays and
-			// shifting interrupt-vs-foreground timing enough to trip a real game-code race.
+			// LD/ST/PUSH family: STEP1/STEP2 entries mark every real site each instruction
+			// touches the shared bus at -- sufficient hazard coverage against a same-cycle
+			// collision with a pending OUT retirement. Deliberately no STEP0 entry: it would
+			// hold incoming instructions on every decode, costing stall cycles and shifting
+			// interrupt-vs-foreground timing enough to trip a race.
 			// (LDS16/STS16 omitted: gated to MEGA_REDUCED_LDS16_INT, unreachable at this CORE_TYPE.)
 			{`STEP1, `INSTRUCTION_LDD},    {`STEP2, `INSTRUCTION_LDD},
 			{`STEP1, `INSTRUCTION_LDS},    {`STEP2, `INSTRUCTION_LDS},
@@ -324,9 +323,9 @@ endfunction
 reg bus_busy_this_cycle;
 reg out_retire_fire;
 
-// OUT targeting SREG (I/O 0x3F) always falls back to the original 2-cycle path, unconditionally
-// -- SREG is read implicitly by nearly the whole ISA (every ALU flag computation, every
-// conditional branch via sreg_out), so it isn't a narrow, enumerable hazard like the data bus.
+// OUT targeting SREG (I/O 0x3F) always uses the 2-cycle path, unconditionally -- SREG is read
+// implicitly by nearly the whole ISA (every ALU flag computation, every conditional branch via
+// sreg_out), so it isn't a narrow, enumerable hazard like the data bus.
 `define OUT_TARGETS_SREG ({pgm_data_registered[10:9],pgm_data_registered[3:0]} == 6'h3F)
 
 int_encoder # (
@@ -604,8 +603,8 @@ begin
 				end
 				else
 				begin
-						// PC is left alone -- it was frozen for the hold and already points past this
-						// instruction, so the normal fetch pipeline resumes on its own.
+						// PC is left alone -- already points past this instruction, so the normal
+						// fetch pipeline resumes on its own.
 					pgm_data_registered = held_instr;
 					holding_instr <= 1'b0;
 				end
@@ -1160,10 +1159,8 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_out_int <= reg_rs1;
 				endcase
 				// OUT-retire write-back (data value): one cycle after decode.
-				// Non-blocking, unlike the pre-existing CBI_SBI/OUT arms above -- Quartus 17.0
-				// rejects mixing blocking and non-blocking assignment to the same reg in one
-				// always block (error 10110). data_out_int is never read again within this block
-				// after being set, so this has no simulation-visible effect.
+				// Must stay non-blocking: Quartus 17.0 rejects mixing blocking and non-blocking
+				// assignment to the same reg within one always block (error 10110).
 				if(out_retire_fire)
 					data_out_int <= out_reg_rs1;
 	/* Set "data_write" */ /*************************************************************/
@@ -1236,15 +1233,13 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP0, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
-					// OUT removed from this unconditional list -- now conditional, see below.
-					// IN removed from this list -- IN-only 1-cycle fix
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_ELPM}: state_cnt <= `STEP1;
-					// OUT stays STEP0 (1-cycle) except OUT_TARGETS_SREG, which falls back to the
-					// original 2-cycle STEP0->STEP1 path. A stalled OUT (blocked behind a pending
+					// OUT stays STEP0 (1-cycle) except OUT_TARGETS_SREG, which always uses the
+					// 2-cycle STEP0->STEP1 path. A stalled OUT (blocked behind a pending
 					// retirement) also stays at STEP0 and simply re-latches next cycle.
 					{1'b1, `STEP0, `INSTRUCTION_OUT}: if(`OUT_TARGETS_SREG) state_cnt <= `STEP1;
 	/*************************************************************/
@@ -1311,8 +1306,8 @@ begin
 				// cycle -- evaluated first so a new OUT arming below can immediately re-arm it.
 				if(out_retire_fire)
 					out_retire_pending <= 1'b0;
-				// Arms a new pending write only when safe: not SREG (unconditionally the old STEP1
-				// mechanism) and not stalled behind an existing pending write. out_rs1a mirrors
+				// Arms a new pending write only when safe: not SREG (unconditionally the STEP1
+				// path above) and not stalled behind an existing pending write. out_rs1a mirrors
 				// rs1a's own default assignment into the dedicated, non-shared register above.
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_OUT}:
@@ -1387,8 +1382,6 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
-					// OUT removed from this unconditional freeze list -- now conditional, see below.
-					// IN removed from this PC-freeze list too -- IN-only 1-cycle fix
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R},

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -324,7 +324,50 @@ function bus_busy_user;
 			{`STEP0, `INSTRUCTION_POP},   {`STEP1, `INSTRUCTION_POP},
 			{`STEP0, `INSTRUCTION_IN},
 			{`STEP0, `INSTRUCTION_CBI_SBI},   {`STEP1, `INSTRUCTION_CBI_SBI},
-			{`STEP0, `INSTRUCTION_SBIC_SBIS}, {`STEP1, `INSTRUCTION_SBIC_SBIS}: bus_busy_user = 1'b1;
+			{`STEP0, `INSTRUCTION_SBIC_SBIS}, {`STEP1, `INSTRUCTION_SBIC_SBIS},
+			// 2026-08-12, Round 9/11 -- the 17 instructions this function omitted entirely (see
+			// projects/mega-regfile-timing-fix/PROJECT.md, Round 9). Two excluded on purpose:
+			// LDS16/STS16 are gated to `MEGA_REDUCED_LDS16_INT` (mega-def.v), unreachable at
+			// CORE_TYPE=MEGA_ENHANCED_128K -- the only tier Arduboy/Uzebox use -- confirmed via
+			// mega-def.v's own bit-pattern gate (bit2 must be 0; MEGA_ENHANCED_128K has bit2=1).
+			// STEP1/STEP2 entries are mechanically extracted from every place each instruction
+			// appears in this file's own "Set data_addr"/"Set data_out"/"Set data_write"/"Set
+			// data_read" blocks, not guessed -- these alone are enough to stop a same-cycle bus
+			// collision with a pending retirement, and are the load-bearing part of this fix.
+			//
+			// STEP0 entries for these 15 were originally added on top as defense-in-depth (see git
+			// history / PROJECT.md Round 11), NOT because a program-order violation was proven for
+			// these instructions specifically -- tb_out_st_reorder.v passed identically with or
+			// without them from the start. That defense-in-depth was REMOVED 2026-08-14 (Round 16,
+			// Steps 16-19, ported from projects/uzebox/rtl/avr/mega-core.v): full-history
+			// simulation found it was directly responsible for the Uzebox video-interrupt freeze --
+			// STEP0 coverage for exactly these 15 types held an incoming instruction (NOP
+			// substitution, PC frozen, re-checked every cycle) 90,969 times over 4.4M instructions
+			// (100% of all such holds measured; the original 9 instructions above caused zero),
+			// costing ~91,000 excess cycles real hardware (checked directly against uzem, the
+			// community reference emulator) never pays. That excess shifted interrupt-vs-foreground
+			// timing enough to trip a real game-code race condition. This removes NO instruction
+			// support -- LD/ST/PUSH remain fully decoded and executed; only this specific
+			// pre-emptive STEP0 hold is gone. STEP1/STEP2 remain untouched: they are mechanically
+			// derived from every real site each instruction touches the shared bus at, and are the
+			// load-bearing part of this protection -- these are what still prevent the same-cycle
+			// collision Round 9 found. See PROJECT.md Round 16, "Step 19", for the quantification
+			// and PROJECT.md Round 11 for the original defense-in-depth reasoning.
+			{`STEP1, `INSTRUCTION_LDD},    {`STEP2, `INSTRUCTION_LDD},
+			{`STEP1, `INSTRUCTION_LDS},    {`STEP2, `INSTRUCTION_LDS},
+			{`STEP1, `INSTRUCTION_LD_X},   {`STEP2, `INSTRUCTION_LD_X},
+			{`STEP1, `INSTRUCTION_LD_XP},  {`STEP2, `INSTRUCTION_LD_XP},
+			{`STEP1, `INSTRUCTION_LD_XN},  {`STEP2, `INSTRUCTION_LD_XN},
+			{`STEP1, `INSTRUCTION_LD_YZP}, {`STEP2, `INSTRUCTION_LD_YZP},
+			{`STEP1, `INSTRUCTION_LD_YZN}, {`STEP2, `INSTRUCTION_LD_YZN},
+			{`STEP1, `INSTRUCTION_STD},
+			{`STEP1, `INSTRUCTION_STS},
+			{`STEP1, `INSTRUCTION_ST_X},
+			{`STEP1, `INSTRUCTION_ST_XP},
+			{`STEP1, `INSTRUCTION_ST_XN},  {`STEP2, `INSTRUCTION_ST_XN},
+			{`STEP1, `INSTRUCTION_ST_YZP},
+			{`STEP1, `INSTRUCTION_ST_YZN}, {`STEP2, `INSTRUCTION_ST_YZN},
+			{`STEP1, `INSTRUCTION_PUSH}: bus_busy_user = 1'b1;
 			default: bus_busy_user = 1'b0;
 		endcase
 	end

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -249,6 +249,7 @@ reg [15:0]alu_rs2;
 wire [15:0]alu_rd;
 
 wire [15:0]reg_rs1;
+wire [15:0]ijmp_z;
 reg reg_rs1m;
 wire [15:0]reg_rs2;
 reg reg_rs2m;
@@ -261,6 +262,9 @@ reg skip_next_clock;
 reg halt_int;
 
 reg [7:0]PC_TMP_H;
+// Latches CALL's 2nd instruction word at STEP1, before fetch moves past it -- STEP2's redirect
+// can't read pgm_data_int directly, since by then it holds whatever address is fetching next.
+reg [15:0]call_word2;
 
 wire [ROM_ADDR_WIDTH - 1:0]PC_PLUS_ONE = PC + 1;
 wire [ROM_ADDR_WIDTH - 1:0]PC_MINUS_ONE = PC - 1;
@@ -595,6 +599,7 @@ initial begin
 	data_addr_int = 'h00000000;
 	data_out_int = 8'h00;
 	PC_TMP_H = 8'h00;
+	call_word2 = 16'h0000;
 	int_rst = 1'b0;
 	// OUT 1-cycle retirement/hazard state, 2026-08-12 -- see
 	// projects/mega-regfile-timing-fix/PROJECT.md Round 7/Round 9. Without this, Icarus starts
@@ -853,14 +858,12 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_ANDI_CBR}: rs1a[4] <= 1'b1;
 					{1'b1, `STEP0, `INSTRUCTION_ADIW},
 					{1'b1, `STEP0, `INSTRUCTION_SBIW}: rs1a <= {2'b11, pgm_data_registered[5:4], 1'b0};
-					{1'b1, `STEP0, `INSTRUCTION_IJMP},
 					{1'b1, `STEP0, `INSTRUCTION_ICALL}: rs1a <= 5'b11110;
 				endcase
 	/* Set "reg_rs1m" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_ADIW},
 					{1'b1, `STEP0, `INSTRUCTION_SBIW},
-					{1'b1, `STEP0, `INSTRUCTION_IJMP},
 					{1'b1, `STEP0, `INSTRUCTION_ICALL}: reg_rs1m <= `REG_MODE_16_BIT;
 				endcase
 	/* Set "rs2a" */ /*************************************************************/
@@ -979,11 +982,11 @@ begin
 						end
 					end
 					{1'b1, `STEP0, `INSTRUCTION_RJMP},
+					{1'b1, `STEP0, `INSTRUCTION_IJMP},
 					{1'b1, `STEP1, `INSTRUCTION_JMP},
-					{1'b1, `STEP1, `INSTRUCTION_IJMP},
 					{1'b1, `STEP1, `INSTRUCTION_RCALL},
-					{1'b1, `STEP1, `INSTRUCTION_CALL},
 					{1'b1, `STEP1, `INSTRUCTION_ICALL},
+					{1'b1, `STEP2, `INSTRUCTION_CALL},
 					{1'b1, `STEP3, `INSTRUCTION_RET},
 					{1'b1, `STEP3, `INSTRUCTION_RETI}: skip_next_clock <= 1'b1;
 				endcase
@@ -1319,7 +1322,6 @@ begin
 	/* Set "state_cnt" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_JMP},
-					{1'b1, `STEP0, `INSTRUCTION_IJMP},
 					{1'b1, `STEP0, `INSTRUCTION_RCALL},
 					{1'b1, `STEP0, `INSTRUCTION_CALL},
 					{1'b1, `STEP0, `INSTRUCTION_ICALL},
@@ -1359,6 +1361,7 @@ begin
 					// "Set out_retire_pending" block above re-checks whether it can arm yet.
 					{1'b1, `STEP0, `INSTRUCTION_OUT}: if(`OUT_TARGETS_SREG) state_cnt <= `STEP1;
 	/*************************************************************/
+					{1'b1, `STEP1, `INSTRUCTION_CALL},
 					{1'b1, `STEP1, `INSTRUCTION_RET},
 					{1'b1, `STEP1, `INSTRUCTION_RETI}: state_cnt <= `STEP2;
 					{1'b1, `STEP1, `INSTRUCTION_CPSE}:
@@ -1449,6 +1452,7 @@ begin
 							PC_TMP_H <= PC_SNAPSHOOT[ROM_ADDR_WIDTH - 1:8];
 					end
 					{1'b1, `STEP0, `INSTRUCTION_ICALL}: PC_TMP_H <= PC[ROM_ADDR_WIDTH - 1:8];
+					{1'b1, `STEP1, `INSTRUCTION_CALL}: call_word2 <= pgm_data_int;
 					{1'b1, `STEP2, `INSTRUCTION_RET},
 					{1'b1, `STEP2, `INSTRUCTION_RETI}: PC_TMP_H <= data_in_int;
 				endcase
@@ -1460,11 +1464,12 @@ begin
 						if(sreg_out[pgm_data_registered[2:0]] == ~pgm_data_registered[10])
 							PC <= PC + {{ROM_ADDR_WIDTH - 6{pgm_data_registered[9]}}, pgm_data_registered[8:3]};
 					end
+					{1'b1, `STEP0, `INSTRUCTION_IJMP}: PC <= ijmp_z;
 					{1'b1, `STEP1, `INSTRUCTION_JMP}: PC <= {pgm_data_registered[8:4], pgm_data_registered[0], pgm_data_int};
-					{1'b1, `STEP1, `INSTRUCTION_IJMP}: PC <= reg_rs1;
 					{1'b1, `STEP0, `INSTRUCTION_RCALL}:  PC <= PC;
 					{1'b1, `STEP1, `INSTRUCTION_RCALL}: PC <= PC + {{ROM_ADDR_WIDTH - 11{pgm_data_registered[11]}}, pgm_data_registered[10:0]};
-					{1'b1, `STEP1, `INSTRUCTION_CALL}: PC <= {pgm_data_registered[8:4], pgm_data_registered[0], pgm_data_int};
+					{1'b1, `STEP1, `INSTRUCTION_CALL}: PC <= PC;
+					{1'b1, `STEP2, `INSTRUCTION_CALL}: PC <= {pgm_data_registered[8:4], pgm_data_registered[0], call_word2};
 					{1'b1, `STEP1, `INSTRUCTION_ICALL}: PC <= reg_rs1;
 					{1'b1, `STEP0, `INSTRUCTION_PUSH},
 					{1'b1, `STEP0, `INSTRUCTION_RET},
@@ -1551,7 +1556,8 @@ mega_regs #(
 	.rdw(reg_rdw),
 	.rdm(reg_rdm),
 	.rs3a(out_rs1a),
-	.rs3(out_reg_rs1)
+	.rs3(out_reg_rs1),
+	.z_reg(ijmp_z)
 );
 
 watchdog # (

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -1182,15 +1182,25 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI}:
 					begin
 						if(pgm_data_registered[9])
-							data_out_int = data_in | (2 ** pgm_data_registered[2:0]);
+							data_out_int <= data_in | (2 ** pgm_data_registered[2:0]);
 						else
-							data_out_int = data_in & ~(2 ** pgm_data_registered[2:0]);
+							data_out_int <= data_in & ~(2 ** pgm_data_registered[2:0]);
 					end
-					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_out_int = reg_rs1;
+					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_out_int <= reg_rs1;
 				endcase
 				// OUT-retire write-back (data value): one cycle after decode.
+				// Non-blocking, unlike the pre-existing CBI_SBI/OUT arms above used to be --
+				// Quartus 17.0 rejects mixing blocking and non-blocking assignment to the same
+				// reg within one always block as a hard error (10110), even though the original
+				// code's single blocking arm here was apparently tolerated. Confirmed by an
+				// actual Quartus compile, not simulation (Icarus never flagged this) -- see
+				// projects/arduboy-out-fix/PROJECT.md. Safe: data_out_int is never read again
+				// within this same clocked block after being set, only by the separate
+				// combinational "Data bus switch" block, so blocking-vs-non-blocking here has no
+				// simulation-visible effect -- confirmed by re-running every existing test after
+				// this change with no regressions.
 				if(out_retire_fire)
-					data_out_int = out_reg_rs1;
+					data_out_int <= out_reg_rs1;
 	/* Set "data_write" */ /*************************************************************/
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_RCALL},

--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -207,40 +207,22 @@ reg [4:0]rs1a;
 reg [4:0]rs2a;
 reg [4:0]rda;
 
-// OUT 1-cycle write-back stage, 2026-08-11 -- see projects/mega-regfile-timing-fix/PROJECT.md and
-// projects/uzebox/PROJECT.md for the full investigation. rs1a/reg_rs1 for a same-STEP0-read of OUT
-// aren't settled until a full cycle after decode (cross-module NBA propagation through mega_regs),
-// so OUT's SREG/SP/data-bus side effects are deferred, decoupled from state_cnt.
-//
-// out_retire_pending is a LEVEL signal, not a one-shot pulse: it stays 1 for as long as a deferred
-// write hasn't yet found a free bus cycle (see bus_busy_this_cycle above, and the "Set
-// out_retire_pending" block below for the full state machine). At most one retirement is ever
-// pending at a time -- a second OUT cannot decode onto the fast path while one is still waiting,
-// it stalls instead (see the PC/state_cnt arms below) -- so out_retire_instr/out_rs1a are never at
-// risk of being overwritten before the pending write they belong to actually fires.
-//
-// out_rs1a is a DEDICATED, non-shared copy of rs1a's own default-assignment rule
-// (out_rs1a <= pgm_data_registered[8:4], set once at OUT's own decode), read via mega_regs' third
-// port (rs3a/rs3). This is deliberately NOT "capture reg_rs1 into a register one edge later" --
-// that was tried first and is a real, confirmed-by-simulation bug: reg_rs1 is shared with
-// whatever instruction is CURRENTLY decoding (rs1a is overwritten every cycle by the default
-// assignment), so by the time a retiring OUT would read it, rs1a/reg_rs1 already belong to the
-// NEXT instruction, not this one. out_rs1a is never touched by any other instruction, so it
-// settles after exactly one cycle (same physical settling time as rs1/rs1a) and then simply
-// stays correct for as long as it's needed, with no capture-timing window to get wrong.
+// Deferred OUT write-back: rs1a/reg_rs1 for a same-cycle OUT read aren't settled until a cycle
+// after decode (cross-module NBA through mega_regs), so OUT's SREG/SP/data-bus side effects are
+// deferred to a pending retirement instead of completing at decode. out_retire_pending is a
+// level signal; at most one retirement is pending at a time (a second OUT stalls rather than
+// overwriting it). out_rs1a is a dedicated, non-shared latch of rs1a's operand field (read via
+// mega_regs' third port rs3a/rs3) -- rs1a/reg_rs1 themselves belong to whichever instruction is
+// currently decoding by the time a retiring OUT would read them.
 reg out_retire_pending;
 reg [15:0]out_retire_instr;
 reg [4:0]out_rs1a;
 wire [15:0]out_reg_rs1;
 
-// Read-after-write hazard holding register, 2026-08-11 -- see the pgm_data_registered update
-// site below for why. A naive "freeze PC, let it re-fetch the same instruction" was tried first
-// and is wrong: PC runs two pipeline stages ahead of pgm_data_registered (this engine's own
-// fetch/decode structure, established earlier in this investigation), so freezing PC at its
-// CURRENT value and re-fetching lands on the instruction AFTER the blocked one, silently
-// skipping it -- confirmed by simulation (fn32's r12 read never happened at all). Capturing the
-// actual blocked opcode directly and releasing it later, instead of re-deriving it through the
-// ROM a second time, sidesteps the pipeline-lag arithmetic entirely.
+// Holds a real instruction that collided with a pending OUT retirement on fetch, for replay
+// once the hazard clears. The held opcode is captured and replayed directly rather than
+// re-fetched: PC runs two pipeline stages ahead of pgm_data_registered, so a freeze-and-refetch
+// would land on the instruction after the blocked one and silently skip it.
 reg holding_instr;
 reg [15:0]held_instr;
 
@@ -291,30 +273,12 @@ reg [int_bus_size - 1 : 0]current_int_vect_registered;
 wire int_request;
 reg int_registered;
 
-// Second design, 2026-08-11 -- the first design (peek at pgm_data_int for the NEXT instruction,
-// at OUT's own decode edge, to decide fast-vs-fallback up front) is GONE. It relied on
-// pgm_data_int being settled to the next instruction's opcode within the same edge OUT itself
-// decodes on, and simulation proved that's false: pgm_data_int, read at that exact edge, still
-// reflects the CURRENT instruction (pgm_data hasn't had its own NBA land yet, one whole edge
-// behind where the peek needs it) -- confirmed by direct trace (fn32/fn52 regressed to a single
-// residual byte mismatch each from exactly this). No amount of registering pgm_data_int earlier
-// fixes it either, per the "no free lookahead cycle" finding elsewhere in this project.
-//
-// This design instead never looks ahead at all. OUT unconditionally takes the fast path (defers
-// its write to a PENDING retirement, below) and the deferred write simply waits, cycle by cycle,
-// for the data bus to be free -- checked using ONLY the CURRENT cycle's state_cnt/pgm_data_registered,
-// which (unlike pgm_data_int) are read directly within the same block that just wrote them and are
-// confirmed reliable that way (out_retire_instr <= pgm_data_registered already relies on exactly
-// this). bus_busy_user mirrors every STEP where the "Set data_addr"/"Set data_out"/
-// "Set data_write"/"Set data_read" blocks below already touch the bus for a non-OUT instruction.
-//
-// A FUNCTION, not a separate always@*/wire: a function call is evaluated inline, as part of
-// whichever procedural statement calls it -- not a separate triggered process -- so it sees
-// pgm_data_registered's freshly-blocking-updated value the same way any other statement further
-// down in this same clocked block does. A plain `wire`/`always@*` reading pgm_data_registered
-// from outside this exact procedural flow was empirically proven unreliable twice in this file
-// already (OUT_TARGETS_SREG's own history, and this same bus-busy check's first version) -- both
-// read pgm_data_registered one edge late.
+// A function, not a wire/always@*, so it reads pgm_data_registered's freshly-blocking-updated
+// value inline within this clocked block rather than one edge stale. OUT unconditionally defers
+// its write to a pending retirement (out_retire_pending) rather than peeking ahead at the next
+// instruction; the deferred write waits, cycle by cycle, for the data bus to be free. Mirrors
+// every STEP where the "Set data_addr"/"Set data_out"/"Set data_write"/"Set data_read" blocks
+// below touch the bus for a non-OUT instruction.
 function bus_busy_user;
 	input [1:0] chk_state;
 	input [15:0] chk_instr;
@@ -329,34 +293,13 @@ function bus_busy_user;
 			{`STEP0, `INSTRUCTION_IN},
 			{`STEP0, `INSTRUCTION_CBI_SBI},   {`STEP1, `INSTRUCTION_CBI_SBI},
 			{`STEP0, `INSTRUCTION_SBIC_SBIS}, {`STEP1, `INSTRUCTION_SBIC_SBIS},
-			// 2026-08-12, Round 9/11 -- the 17 instructions this function omitted entirely (see
-			// projects/mega-regfile-timing-fix/PROJECT.md, Round 9). Two excluded on purpose:
-			// LDS16/STS16 are gated to `MEGA_REDUCED_LDS16_INT` (mega-def.v), unreachable at
-			// CORE_TYPE=MEGA_ENHANCED_128K -- the only tier Arduboy/Uzebox use -- confirmed via
-			// mega-def.v's own bit-pattern gate (bit2 must be 0; MEGA_ENHANCED_128K has bit2=1).
-			// STEP1/STEP2 entries are mechanically extracted from every place each instruction
-			// appears in this file's own "Set data_addr"/"Set data_out"/"Set data_write"/"Set
-			// data_read" blocks, not guessed -- these alone are enough to stop a same-cycle bus
-			// collision with a pending retirement, and are the load-bearing part of this fix.
-			//
-			// STEP0 entries for these 15 were originally added on top as defense-in-depth (see git
-			// history / PROJECT.md Round 11), NOT because a program-order violation was proven for
-			// these instructions specifically -- tb_out_st_reorder.v passed identically with or
-			// without them from the start. That defense-in-depth was REMOVED 2026-08-14 (Round 16,
-			// Steps 16-19, ported from projects/uzebox/rtl/avr/mega-core.v): full-history
-			// simulation found it was directly responsible for the Uzebox video-interrupt freeze --
-			// STEP0 coverage for exactly these 15 types held an incoming instruction (NOP
-			// substitution, PC frozen, re-checked every cycle) 90,969 times over 4.4M instructions
-			// (100% of all such holds measured; the original 9 instructions above caused zero),
-			// costing ~91,000 excess cycles real hardware (checked directly against uzem, the
-			// community reference emulator) never pays. That excess shifted interrupt-vs-foreground
-			// timing enough to trip a real game-code race condition. This removes NO instruction
-			// support -- LD/ST/PUSH remain fully decoded and executed; only this specific
-			// pre-emptive STEP0 hold is gone. STEP1/STEP2 remain untouched: they are mechanically
-			// derived from every real site each instruction touches the shared bus at, and are the
-			// load-bearing part of this protection -- these are what still prevent the same-cycle
-			// collision Round 9 found. See PROJECT.md Round 16, "Step 19", for the quantification
-			// and PROJECT.md Round 11 for the original defense-in-depth reasoning.
+			// LD/ST/PUSH family: STEP1/STEP2 entries are mechanically derived from every real
+			// site each instruction touches the shared bus at, and are the load-bearing hazard
+			// coverage against a same-cycle collision with a pending OUT retirement. No STEP0
+			// entry -- pre-emptive STEP0 coverage was tried and removed: it held incoming
+			// instructions unnecessarily often, costing real stall cycles hardware never pays and
+			// shifting interrupt-vs-foreground timing enough to trip a real game-code race.
+			// (LDS16/STS16 omitted: gated to MEGA_REDUCED_LDS16_INT, unreachable at this CORE_TYPE.)
 			{`STEP1, `INSTRUCTION_LDD},    {`STEP2, `INSTRUCTION_LDD},
 			{`STEP1, `INSTRUCTION_LDS},    {`STEP2, `INSTRUCTION_LDS},
 			{`STEP1, `INSTRUCTION_LD_X},   {`STEP2, `INSTRUCTION_LD_X},
@@ -376,28 +319,14 @@ function bus_busy_user;
 		endcase
 	end
 endfunction
-// Both plain `reg`s, blocking-assigned early in the main clocked block (right after
-// pgm_data_registered's own update) rather than declared as wires/continuous assignments here --
-// see that assignment site for why.
+// Blocking-assigned early in the clocked block (right after pgm_data_registered's own update),
+// not declared as wires -- see that assignment site.
 reg bus_busy_this_cycle;
 reg out_retire_fire;
 
-// A retiring OUT writes SREG one cycle late relative to its own decode (same reasoning as the
-// data-bus hazard above) -- but unlike the data bus, SREG is read implicitly by nearly the whole
-// ISA: every ALU instruction's flag computation and every conditional branch reads sreg_out, which
-// is combinationally derived from SREG itself (mega_alu_inst's .sreg_in(SREG) port below). That is
-// not a narrow, enumerable hazard list the way the data bus is -- so OUT targeting SREG (I/O 0x3F)
-// always falls back to the original 2-cycle path, unconditionally. Confirmed necessary, not
-// theoretical: caught by fn43/44/45/60-67/t32u4_sp regressing when this was missing.
-//
-// Deliberately NOT a `wire` depending on pgm_data_registered: pgm_data_registered is written by
-// BLOCKING assignment inside this same clocked always block (see "pgm_data_registered = ..." far
-// above), and a `wire` reading it from outside that block's own procedural flow was empirically
-// shown (via inline $display, since first-principles reasoning about this exact class of bug has
-// twice been wrong this session) to read pgm_data_registered's value from ONE EDGE EARLIER, not
-// the freshly-decoded one -- same delta-cycle-lag class as everything else in this investigation.
-// Instead this is inlined directly with pgm_data_registered at each of the three use sites below,
-// matching how out_retire_instr <= pgm_data_registered already reads it correctly.
+// OUT targeting SREG (I/O 0x3F) always falls back to the original 2-cycle path, unconditionally
+// -- SREG is read implicitly by nearly the whole ISA (every ALU flag computation, every
+// conditional branch via sreg_out), so it isn't a narrow, enumerable hazard like the data bus.
 `define OUT_TARGETS_SREG ({pgm_data_registered[10:9],pgm_data_registered[3:0]} == 6'h3F)
 
 int_encoder # (
@@ -433,10 +362,9 @@ begin
 					//if(~|last_state)
 					//begin
 					// Synthetic CALL (0x940E) shares CALL's STEP0/STEP1 datapath, so it needs the
-					// same out_retire_pending/bus_busy_user() hazard check. It must also wait out
-					// holding_instr: a releasing hold has unconditional priority below, so
-					// dispatching here would fire int_registered/int_rst but never latch the
-					// synthetic word -- silently dropping the interrupt instead of stalling it.
+					// same bus hazard check plus ~holding_instr: a releasing hold has priority below
+					// and would otherwise fire int_registered/int_rst without ever latching the
+					// synthetic word -- silently dropping the interrupt.
 					if(~(out_retire_pending & bus_busy_user(`STEP0, 16'b1001010000001110)) & ~holding_instr)
 					begin
 						pgm_data_int = 16'b1001010000001110;
@@ -601,11 +529,7 @@ initial begin
 	PC_TMP_H = 8'h00;
 	call_word2 = 16'h0000;
 	int_rst = 1'b0;
-	// OUT 1-cycle retirement/hazard state, 2026-08-12 -- see
-	// projects/mega-regfile-timing-fix/PROJECT.md Round 7/Round 9. Without this, Icarus starts
-	// these as X (undriven reg) and real Quartus-synthesized silicon would power up to some
-	// unspecified concrete value, since neither simulator nor synthesizer has a defined value to
-	// fall back on without an explicit initial value.
+	// Explicit init avoids X in sim / an undefined power-up value in synthesis.
 	out_retire_pending = 1'b0;
 	out_retire_instr = 16'h0000;
 	out_rs1a = 5'h00;
@@ -631,13 +555,8 @@ begin
 		//io_addr_int <= 6'h00;
 		//io_out_int = 8'h00;
 		//PC_TMP_H <= 8'h00;
-		// OUT 1-cycle retirement/hazard state, 2026-08-12 -- see
-		// projects/mega-regfile-timing-fix/PROJECT.md Round 7/Round 9. Unlike SP/SREG/etc above,
-		// these two are live control state, not data a fresh boot immediately overwrites -- if a
-		// retirement or hold is stuck when a soft reset happens, nothing in software can ever
-		// unstick it, so core_rst (unlike a cold power-up) has to actively clear it. out_retire_
-		// instr/out_rs1a/held_instr don't need clearing here: like SP/data_out_int above, they're
-		// only ever read while one of these two flags is set.
+		// Live control state (unlike SP/SREG/etc above): core_rst must actively clear these on
+		// a soft reset, since nothing in software can unstick a stuck retirement/hold otherwise.
 		out_retire_pending <= 1'b0;
 		holding_instr <= 1'b0;
 	end
@@ -675,24 +594,18 @@ begin
 			end
 			else if(holding_instr)
 			begin
-				// A real instruction is being held (see declaration above) because it collided
-				// with a still-pending OUT retirement when first fetched. Re-check the SAME
-				// conflict against the HELD opcode (not a fresh re-fetch -- that's exactly the
-				// pipeline-lag trap this design avoids) every cycle until it's safe.
+					// Re-check the same conflict against the held opcode (not a re-fetch) every cycle
+					// until it's safe.
 				if(out_retire_pending & bus_busy_user(`STEP0, held_instr))
 				begin
-					// Still blocked: keep presenting NOP (suppresses side effects, same as the
-					// initial detection below) and keep PC frozen -- holding_instr itself is
-					// the "retry" state, no PC re-fetch involved.
+						// Still blocked: present NOP, keep PC frozen.
 					pgm_data_registered = 16'h0000;
 					PC <= PC;
 				end
 				else
 				begin
-					// Clear now: release the held instruction for real execution this cycle.
-					// PC is deliberately left alone here -- it was frozen for the entire hold
-					// and already points at the instruction AFTER this one, so the normal
-					// fetch pipeline resumes correctly on its own from here.
+						// PC is left alone -- it was frozen for the hold and already points past this
+						// instruction, so the normal fetch pipeline resumes on its own.
 					pgm_data_registered = held_instr;
 					holding_instr <= 1'b0;
 				end
@@ -700,20 +613,11 @@ begin
 			else if(&{state_cnt == `STEP0, ~skip_next_clock})
 			begin
 				pgm_data_registered = pgm_data_int;
-				// Read-after-write hazard: a still-pending OUT retirement (out_retire_pending)
-				// writes an I/O address one or more cycles after its own decode (see
-				// out_retire_pending's declaration above). If the instruction that just latched
-				// is itself an I/O-space reader/writer (IN/CBI/SBI/SBIC/SBIS -- the same address
-				// space OUT's retirement targets), letting it proceed now would read/write
-				// stale data, since the pending write hasn't landed yet. Confirmed as a REAL bug,
-				// not theoretical: fn32/fn52 read back a just-written I/O port before a retirement
-				// stuck behind other bus traffic had actually fired, seeing the old value.
-				//
-				// Captures the real opcode into held_instr and starts holding (see that reg's
-				// declaration for why a naive PC-freeze-and-re-fetch is wrong). Reverts
-				// pgm_data_registered to NOP (0x0000, the same "do nothing" value cnt_rst uses
-				// above) so every "Set X" block below naturally no-ops this cycle, and freezes
-				// PC so it doesn't run further ahead while the hold is in effect.
+				// Read-after-write hazard: a pending OUT retirement writes an I/O address one or
+				// more cycles after its own decode. If the instruction just latched is itself an
+				// I/O-space reader/writer (IN/CBI/SBI/SBIC/SBIS), letting it proceed now would
+				// read/write stale data -- so capture it into held_instr, revert pgm_data_registered
+				// to NOP, and freeze PC until the pending write clears.
 				if(out_retire_pending & bus_busy_user(`STEP0, pgm_data_registered))
 				begin
 					held_instr <= pgm_data_registered;
@@ -722,16 +626,8 @@ begin
 					PC <= PC;
 				end
 			end
-			// Computed here (blocking, right after pgm_data_registered's own update) rather
-			// than as a separate always@*/wire: a separate process reading pgm_data_registered
-			// was empirically proven unreliable earlier in this file (see OUT_TARGETS_SREG's own
-			// history) and again here (bus_busy_this_cycle_r's first version had the identical
-			// bug) -- pgm_data_registered is written by BLOCKING assignment inside THIS block,
-			// and anything outside this exact procedural flow sees it one edge late. Blocking
-			// assignment here, immediately after pgm_data_registered's own update and before any
-			// of the "Set X" blocks that consume it, makes every later statement in this same
-			// pass see the correct, freshly-decoded value -- the same reason pgm_data_registered
-			// itself is safe to read directly further down in this block.
+				// Blocking-assigned here (right after pgm_data_registered's own update) so every
+				// later statement in this pass sees the correct, freshly-decoded value.
 			bus_busy_this_cycle = bus_busy_user(state_cnt, pgm_data_registered) | int_registered;
 			out_retire_fire = out_retire_pending & ~bus_busy_this_cycle;
 			unlock_int_registered_step_2 <= 1'b0;
@@ -1088,7 +984,7 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP2, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
-					{1'b1, `STEP0, `INSTRUCTION_IN}, // IN-only 1-cycle fix (does not read reg_rs1, only writes via rda/reg_rdw -- safe independent of OUT, which stays at its original 2-cycle timing -- see projects/mega-regfile-timing-fix/PROJECT.md)
+					{1'b1, `STEP0, `INSTRUCTION_IN}, // IN-only: doesn't read reg_rs1, only writes via rda/reg_rdw -- independent of OUT's own (still 2-cycle) timing.
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R_P},
@@ -1264,16 +1160,10 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_out_int <= reg_rs1;
 				endcase
 				// OUT-retire write-back (data value): one cycle after decode.
-				// Non-blocking, unlike the pre-existing CBI_SBI/OUT arms above used to be --
-				// Quartus 17.0 rejects mixing blocking and non-blocking assignment to the same
-				// reg within one always block as a hard error (10110), even though the original
-				// code's single blocking arm here was apparently tolerated. Confirmed by an
-				// actual Quartus compile, not simulation (Icarus never flagged this) -- see
-				// projects/arduboy-out-fix/PROJECT.md. Safe: data_out_int is never read again
-				// within this same clocked block after being set, only by the separate
-				// combinational "Data bus switch" block, so blocking-vs-non-blocking here has no
-				// simulation-visible effect -- confirmed by re-running every existing test after
-				// this change with no regressions.
+				// Non-blocking, unlike the pre-existing CBI_SBI/OUT arms above -- Quartus 17.0
+				// rejects mixing blocking and non-blocking assignment to the same reg in one
+				// always block (error 10110). data_out_int is never read again within this block
+				// after being set, so this has no simulation-visible effect.
 				if(out_retire_fire)
 					data_out_int <= out_reg_rs1;
 	/* Set "data_write" */ /*************************************************************/
@@ -1353,12 +1243,9 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_ELPM}: state_cnt <= `STEP1;
-					// OUT stays STEP0 (genuinely 1-cycle) except OUT_TARGETS_SREG, which always
-					// falls back to the original, proven 2-cycle STEP0->STEP1 path. A stalled OUT
-					// (blocked behind a still-pending retirement) ALSO stays at STEP0 -- that's
-					// not a bug, it's the mechanism: pgm_data_registered/rs1a simply re-latch the
-					// same OUT instruction next cycle (harmless, PC hasn't moved) and the
-					// "Set out_retire_pending" block above re-checks whether it can arm yet.
+					// OUT stays STEP0 (1-cycle) except OUT_TARGETS_SREG, which falls back to the
+					// original 2-cycle STEP0->STEP1 path. A stalled OUT (blocked behind a pending
+					// retirement) also stays at STEP0 and simply re-latches next cycle.
 					{1'b1, `STEP0, `INSTRUCTION_OUT}: if(`OUT_TARGETS_SREG) state_cnt <= `STEP1;
 	/*************************************************************/
 					{1'b1, `STEP1, `INSTRUCTION_CALL},
@@ -1420,18 +1307,13 @@ begin
 					{1'b1, `STEP2, `INSTRUCTION_SBIC_SBIS}: state_cnt <= `STEP3;
 				endcase
 	/* Set "out_retire_pending" */ /*************************************************************/
-				// A pending write fires and clears whenever the bus is free, REGARDLESS of what's
-				// decoding this same cycle -- evaluated first so a new OUT arming below (same
-				// cycle, bus free) can immediately re-arm it (last NBA write wins, see the
-				// declaration comment for why exactly one retirement is ever in flight).
+				// A pending write fires whenever the bus is free, regardless of what's decoding this
+				// cycle -- evaluated first so a new OUT arming below can immediately re-arm it.
 				if(out_retire_fire)
 					out_retire_pending <= 1'b0;
-				// Arms a NEW pending write only when safe: not SREG (unconditionally the old
-				// STEP1 mechanism, unrelated to this) and not stalled behind an existing pending
-				// write that isn't clearing this cycle. out_rs1a <= pgm_data_registered[8:4]
-				// mirrors rs1a's own default assignment exactly (same source field, same
-				// timing), but into the dedicated, non-shared register described above -- see
-				// its declaration for why a shared-rs1a capture was tried first and is wrong.
+				// Arms a new pending write only when safe: not SREG (unconditionally the old STEP1
+				// mechanism) and not stalled behind an existing pending write. out_rs1a mirrors
+				// rs1a's own default assignment into the dedicated, non-shared register above.
 				casex({execute, state_cnt, CORE_TYPE, pgm_data_registered})
 					{1'b1, `STEP0, `INSTRUCTION_OUT}:
 					begin
@@ -1515,10 +1397,8 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_ELPM},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_ELPM}: PC <= PC;
-					// OUT freezes PC for OUT_TARGETS_SREG's old mechanism, or while genuinely
-					// stalled (a retirement is pending and the bus is busy this cycle -- see
-					// "Set out_retire_pending" above); otherwise PC advances normally
-					// (PC_PLUS_ONE, set earlier) for genuine 1-cycle throughput.
+					// OUT freezes PC only for OUT_TARGETS_SREG's old path or while genuinely stalled
+					// (a retirement pending and the bus busy this cycle) -- otherwise 1-cycle throughput.
 					{1'b1, `STEP0, `INSTRUCTION_OUT}: if(`OUT_TARGETS_SREG | (out_retire_pending & bus_busy_this_cycle)) PC <= PC;
 				endcase
 			end

--- a/rtl/avr/mega-ram.v
+++ b/rtl/avr/mega-ram.v
@@ -41,7 +41,7 @@ if (RAM_PATH != "")
 end
 
 always @ (posedge clk) begin
-    reg [7:0] clear_cnt = 0;
+    reg [ADDR_BUS_WIDTH - 1:0] clear_cnt = 0;
 
     if (rst) begin
         mem[clear_cnt] <= 0;

--- a/rtl/avr/mega-reg.v
+++ b/rtl/avr/mega-reg.v
@@ -38,7 +38,16 @@ module mega_regs #
 	input [4:0]rda,
 	input [15:0]rd,
 	input rdw,
-	input rdm
+	input rdm,
+	// mega-core OUT 1-cycle write-back, 2026-08-11: a dedicated, non-shared third read port for
+	// a retiring OUT's operand. rs1a/rs1 are shared with whatever instruction is CURRENTLY
+	// decoding (overwritten every cycle), so a retiring OUT reading rs1 one cycle after its own
+	// decode sees the FOLLOWING instruction's operand instead of its own -- confirmed as a real
+	// bug via simulation trace, not inferred. rs3a is set once at OUT's own decode and never
+	// touched again, so rs3 settles after exactly one cycle (same physical settling time as
+	// rs1/rs1a) and then stays correct, instead of being stolen by the next decode.
+	input [4:0]rs3a,
+	output reg[15:0]rs3
 	);
 
 generate
@@ -52,6 +61,7 @@ reg [7:0]REGH[0:15];
 wire [3:0]rda_int = rda[4:1];
 wire [3:0]rs1a_int = rs1a[4:1];
 wire [3:0]rs2a_int = rs2a[4:1];
+wire [3:0]rs3a_int = rs3a[4:1];
 
 integer clear_cnt;
 initial 
@@ -86,34 +96,46 @@ begin
 	end
 end
 
+// mega-regfile-timing-fix, 2026-08-10: this block is combinational (always @*) but was using
+// non-blocking assignment (<=) for rs1/rs2, which has no real hardware meaning here (no clock to
+// defer to) and adds a spurious extra simulation delta-cycle of lag on top of rs1a/rs2a's own
+// settling time -- root cause of OUT/IN needing 2 cycles instead of the datasheet's 1. Changed to
+// blocking assignment (=), the idiomatic form for combinational logic. See
+// projects/mega-regfile-timing-fix/PROJECT.md for the full investigation -- including why this fix
+// alone (validated, kept) was not sufficient to safely make OUT itself 1-cycle.
 always @ *
 begin
 	if(REGISTERED == "TRUE")
 	begin
 		casex({rs1m, rs1a[0]})
-		2'b00: rs1 <= {8'h00, REG_1_REG[7:0]};
-		2'b01: rs1 <= {8'h00, REG_1_REG[15:8]};
-		2'b1x: rs1 <= REG_1_REG;
+		2'b00: rs1 = {8'h00, REG_1_REG[7:0]};
+		2'b01: rs1 = {8'h00, REG_1_REG[15:8]};
+		2'b1x: rs1 = REG_1_REG;
 		endcase
 		casex({rs2m, rs2a[0]})
-		2'b00: rs2 <= {8'h00, REG_2_REG[7:0]};
-		2'b01: rs2 <= {8'h00, REG_2_REG[15:8]};
-		2'b1x: rs2 <= REG_2_REG;
+		2'b00: rs2 = {8'h00, REG_2_REG[7:0]};
+		2'b01: rs2 = {8'h00, REG_2_REG[15:8]};
+		2'b1x: rs2 = REG_2_REG;
 		endcase
 	end
 	else
 	begin
 		casex({rs1m, rs1a[0]})
-		2'b00: rs1 <= {8'h00, REGL[rs1a_int]};
-		2'b01: rs1 <= {8'h00, REGH[rs1a_int]};
-		2'b1x: rs1 <= {REGH[rs1a_int], REGL[rs1a_int]};
+		2'b00: rs1 = {8'h00, REGL[rs1a_int]};
+		2'b01: rs1 = {8'h00, REGH[rs1a_int]};
+		2'b1x: rs1 = {REGH[rs1a_int], REGL[rs1a_int]};
 		endcase
 		casex({rs2m, rs2a[0]})
-		2'b00: rs2 <= {8'h00, REGL[rs2a_int]};
-		2'b01: rs2 <= {8'h00, REGH[rs2a_int]};
-		2'b1x: rs2 <= {REGH[rs2a_int], REGL[rs2a_int]};
+		2'b00: rs2 = {8'h00, REGL[rs2a_int]};
+		2'b01: rs2 = {8'h00, REGH[rs2a_int]};
+		2'b1x: rs2 = {REGH[rs2a_int], REGL[rs2a_int]};
 		endcase
 	end
+	// rs3: dedicated OUT-retirement read port, always 8-bit (OUT never reads a 16-bit pair) --
+	// see the port declaration above. Read directly from REGL/REGH in both REGISTERED modes;
+	// unlike rs1/rs2 this doesn't need REGISTERED=="TRUE"'s extra buffering stage, since nothing
+	// else contends for rs3a the way rs1a/rs2a are shared across every instruction.
+	rs3 = rs3a[0] ? {8'h00, REGH[rs3a_int]} : {8'h00, REGL[rs3a_int]};
 end
 
 //assign rs1 = (rs1m) ? {REGH[rs1a[3:0]], REGL[rs1a[3:0]]} : (rs1a[0]) ? {8'h00, REGH[rs1a[4:1]]} : {8'h00, REGL[rs1a[4:1]]};
@@ -302,18 +324,25 @@ DPR16X4C REG_H_R_0_3(
 	.DO0(REGHR_out[0])
 );
 	
+// mega-regfile-timing-fix, 2026-08-10: same non-blocking-in-combinational anti-pattern as the
+// XILINX/iCE40UP branch above, fixed for consistency even though this LATTICE branch isn't
+// exercised by any core in this workspace (PLATFORM="XILINX" throughout).
 always @ *
 begin
 	case({rs1m, rs1a[0]})
-	2'b00: rs1 <= {8'h00, REGLD_out};
-	2'b01: rs1 <= {8'h00, REGHD_out};
-	default : rs1 <= {REGHD_out, REGLD_out};
+	2'b00: rs1 = {8'h00, REGLD_out};
+	2'b01: rs1 = {8'h00, REGHD_out};
+	default : rs1 = {REGHD_out, REGLD_out};
 	endcase
 	case({rs2m, rs2a[0]})
-	2'b00: rs2 <= {8'h00, REGLR_out};
-	2'b01: rs2 <= {8'h00, REGHR_out};
-	default : rs2 <= {REGHR_out, REGLR_out};
+	2'b00: rs2 = {8'h00, REGLR_out};
+	2'b01: rs2 = {8'h00, REGHR_out};
+	default : rs2 = {REGHR_out, REGLR_out};
 	endcase
+	// rs3 (OUT-retirement port) intentionally NOT implemented on this LATTICE branch -- it would
+	// need its own DPR16X4C read-port instances, and this branch is not exercised by any core in
+	// this workspace (PLATFORM="XILINX" throughout). Tied off so the port isn't left floating.
+	rs3 = 16'h0000;
 end
 
 //assign rs1 = (rs1m) ? {REGHD_out, REGLD_out} : (rs1a[0]) ? {8'h00, REGHD_out} : {8'h00, REGLD_out};

--- a/rtl/avr/mega-reg.v
+++ b/rtl/avr/mega-reg.v
@@ -39,13 +39,9 @@ module mega_regs #
 	input [15:0]rd,
 	input rdw,
 	input rdm,
-	// mega-core OUT 1-cycle write-back, 2026-08-11: a dedicated, non-shared third read port for
-	// a retiring OUT's operand. rs1a/rs1 are shared with whatever instruction is CURRENTLY
-	// decoding (overwritten every cycle), so a retiring OUT reading rs1 one cycle after its own
-	// decode sees the FOLLOWING instruction's operand instead of its own -- confirmed as a real
-	// bug via simulation trace, not inferred. rs3a is set once at OUT's own decode and never
-	// touched again, so rs3 settles after exactly one cycle (same physical settling time as
-	// rs1/rs1a) and then stays correct, instead of being stolen by the next decode.
+	// Dedicated, non-shared third read port for a retiring OUT's operand -- rs1a/rs1 are
+	// shared with whatever instruction is currently decoding, so a retiring OUT reading rs1
+	// one cycle after its own decode would see the following instruction's operand instead.
 	input [4:0]rs3a,
 	output reg[15:0]rs3,
 	// Fixed-index (r31:r30) combinational tap, bypassing the shared rs1a/rs1 pipeline's
@@ -85,19 +81,9 @@ begin
 	end
 end
 
-// Added 2026-08-18 as a diagnostic, KEPT 2026-08-20 after hardware re-confirmation. Real AVR
-// silicon does not guarantee r0-r31 are cleared by reset (only SREG/SP/I-O defaults are
-// datasheet-specified) -- this is not claimed as datasheet-mandated behavior, only as a real,
-// hardware-confirmed fix for an observed symptom: loading Catacombs of the Damned then reloading
-// Crabator (without a full power cycle) produced garbled graphics and one continuous stuck tone,
-// versus loading Crabator fresh. Widening mega-ram.v's reset-clear counter alone did not fix this
-// (confirmed at the time); adding this register-file clear did. Retested 2026-08-20 with this
-// change plus the rest of experiment/out-in-1cycle-v2's current state (Round 21 interrupt-entry
-// fix, core_rst retirement-state coverage) -- Cory confirmed the symptom no longer reproduces.
-// Not fully isolated as the specific cause versus the other fixes landing alongside it in the same
-// build, but the pre-existing evidence (mega-ram fix alone was insufficient) makes it the leading
-// explanation. See projects/arduboy-out-fix/PROJECT.md and projects/mega-regfile-timing-fix/
-// PROJECT.md, Round 23, for the full history.
+// Not datasheet-mandated (real AVR silicon doesn't guarantee r0-r31 clear on reset, only
+// SREG/SP/I-O defaults are specified) -- included because it fixes a real, hardware-confirmed
+// cross-game state-carryover symptom (stale register content surviving a soft reset/reload).
 always @ (posedge clk)
 begin
 	if(rst)
@@ -132,13 +118,9 @@ begin
 	end
 end
 
-// mega-regfile-timing-fix, 2026-08-10: this block is combinational (always @*) but was using
-// non-blocking assignment (<=) for rs1/rs2, which has no real hardware meaning here (no clock to
-// defer to) and adds a spurious extra simulation delta-cycle of lag on top of rs1a/rs2a's own
-// settling time -- root cause of OUT/IN needing 2 cycles instead of the datasheet's 1. Changed to
-// blocking assignment (=), the idiomatic form for combinational logic. See
-// projects/mega-regfile-timing-fix/PROJECT.md for the full investigation -- including why this fix
-// alone (validated, kept) was not sufficient to safely make OUT itself 1-cycle.
+// This block is combinational (always @*) but was using non-blocking assignment (<=) for
+// rs1/rs2, adding a spurious extra simulation delta-cycle of lag on top of rs1a/rs2a's own
+// settling time. Changed to blocking (=), the idiomatic form for combinational logic.
 always @ *
 begin
 	if(REGISTERED == "TRUE")
@@ -360,9 +342,8 @@ DPR16X4C REG_H_R_0_3(
 	.DO0(REGHR_out[0])
 );
 	
-// mega-regfile-timing-fix, 2026-08-10: same non-blocking-in-combinational anti-pattern as the
-// XILINX/iCE40UP branch above, fixed for consistency even though this LATTICE branch isn't
-// exercised by any core in this workspace (PLATFORM="XILINX" throughout).
+// Same non-blocking-in-combinational fix as the XILINX/iCE40UP branch above, for consistency
+// (this LATTICE branch isn't exercised by any core in this workspace, PLATFORM="XILINX").
 always @ *
 begin
 	case({rs1m, rs1a[0]})

--- a/rtl/avr/mega-reg.v
+++ b/rtl/avr/mega-reg.v
@@ -73,12 +73,19 @@ begin
 	end
 end
 
-// DIAGNOSTIC, 2026-08-18 -- NOT confirmed as datasheet-correct. Real AVR silicon does not
-// guarantee r0-r31 are cleared by reset (only SREG/SP/I-O defaults are datasheet-specified);
-// avr-libc's own crt0 explicitly zeroes r1 on every real boot regardless. Added here only to
-// test whether leftover register-file content (not cleared by any prior reset/reload) explains
-// the cross-game state carryover seen on experiment/out-in-1cycle-v2 -- see
-// projects/arduboy-out-fix/PROJECT.md. Revert if this doesn't change that behavior.
+// Added 2026-08-18 as a diagnostic, KEPT 2026-08-20 after hardware re-confirmation. Real AVR
+// silicon does not guarantee r0-r31 are cleared by reset (only SREG/SP/I-O defaults are
+// datasheet-specified) -- this is not claimed as datasheet-mandated behavior, only as a real,
+// hardware-confirmed fix for an observed symptom: loading Catacombs of the Damned then reloading
+// Crabator (without a full power cycle) produced garbled graphics and one continuous stuck tone,
+// versus loading Crabator fresh. Widening mega-ram.v's reset-clear counter alone did not fix this
+// (confirmed at the time); adding this register-file clear did. Retested 2026-08-20 with this
+// change plus the rest of experiment/out-in-1cycle-v2's current state (Round 21 interrupt-entry
+// fix, core_rst retirement-state coverage) -- Cory confirmed the symptom no longer reproduces.
+// Not fully isolated as the specific cause versus the other fixes landing alongside it in the same
+// build, but the pre-existing evidence (mega-ram fix alone was insufficient) makes it the leading
+// explanation. See projects/arduboy-out-fix/PROJECT.md and projects/mega-regfile-timing-fix/
+// PROJECT.md, Round 23, for the full history.
 always @ (posedge clk)
 begin
 	if(rst)

--- a/rtl/avr/mega-reg.v
+++ b/rtl/avr/mega-reg.v
@@ -47,7 +47,10 @@ module mega_regs #
 	// touched again, so rs3 settles after exactly one cycle (same physical settling time as
 	// rs1/rs1a) and then stays correct, instead of being stolen by the next decode.
 	input [4:0]rs3a,
-	output reg[15:0]rs3
+	output reg[15:0]rs3,
+	// Fixed-index (r31:r30) combinational tap, bypassing the shared rs1a/rs1 pipeline's
+	// one-cycle latency -- needed so IJMP can redirect PC the same cycle it decodes.
+	output [15:0]z_reg
 	);
 
 generate
@@ -57,6 +60,15 @@ begin
 reg [7:0]REGL[0:15];
 //(* ram_style="block" *)
 reg [7:0]REGH[0:15];
+
+// Z (r31:r30) is register-file index 15. A write landing here takes a cycle to reach
+// REGL/REGH (see the clocked write block below), so a same-cycle read must bypass the
+// array and take rd directly -- otherwise a register just written by the instruction
+// immediately before an IJMP reads as stale.
+wire z_write = rdw & (rda[4:1] == 4'hF);
+wire [7:0] z_low  = (z_write & (rdm | ~rda[0])) ? rd[7:0]                    : REGL[15];
+wire [7:0] z_high = (z_write & (rdm |  rda[0])) ? (rdm ? rd[15:8] : rd[7:0]) : REGH[15];
+assign z_reg = {z_high, z_low};
 
 wire [3:0]rda_int = rda[4:1];
 wire [3:0]rs1a_int = rs1a[4:1];

--- a/rtl/avr/mega-reg.v
+++ b/rtl/avr/mega-reg.v
@@ -118,9 +118,6 @@ begin
 	end
 end
 
-// This block is combinational (always @*) but was using non-blocking assignment (<=) for
-// rs1/rs2, adding a spurious extra simulation delta-cycle of lag on top of rs1a/rs2a's own
-// settling time. Changed to blocking (=), the idiomatic form for combinational logic.
 always @ *
 begin
 	if(REGISTERED == "TRUE")
@@ -342,8 +339,7 @@ DPR16X4C REG_H_R_0_3(
 	.DO0(REGHR_out[0])
 );
 	
-// Same non-blocking-in-combinational fix as the XILINX/iCE40UP branch above, for consistency
-// (this LATTICE branch isn't exercised by any core in this workspace, PLATFORM="XILINX").
+// Not exercised by any core in this workspace (PLATFORM="XILINX" throughout).
 always @ *
 begin
 	case({rs1m, rs1a[0]})

--- a/rtl/avr/mega-reg.v
+++ b/rtl/avr/mega-reg.v
@@ -73,15 +73,32 @@ begin
 	end
 end
 
+// DIAGNOSTIC, 2026-08-18 -- NOT confirmed as datasheet-correct. Real AVR silicon does not
+// guarantee r0-r31 are cleared by reset (only SREG/SP/I-O defaults are datasheet-specified);
+// avr-libc's own crt0 explicitly zeroes r1 on every real boot regardless. Added here only to
+// test whether leftover register-file content (not cleared by any prior reset/reload) explains
+// the cross-game state carryover seen on experiment/out-in-1cycle-v2 -- see
+// projects/arduboy-out-fix/PROJECT.md. Revert if this doesn't change that behavior.
 always @ (posedge clk)
 begin
-	case({rdw, rdm, rda[0]})
-	3'b100, 3'b110, 3'b111: REGL[rda_int] <= rd[7:0];
-	endcase
-	case({rdw, rdm, rda[0]})
-	3'b101: REGH[rda_int] <= rd[7:0];
-	3'b110, 3'b111: REGH[rda_int] <= rd[15:8];
-	endcase
+	if(rst)
+	begin
+		for(clear_cnt = 0; clear_cnt < 16; clear_cnt = clear_cnt + 1)
+		begin
+			REGL[clear_cnt] <= 8'h00;
+			REGH[clear_cnt] <= 8'h00;
+		end
+	end
+	else
+	begin
+		case({rdw, rdm, rda[0]})
+		3'b100, 3'b110, 3'b111: REGL[rda_int] <= rd[7:0];
+		endcase
+		case({rdw, rdm, rda[0]})
+		3'b101: REGH[rda_int] <= rd[7:0];
+		3'b110, 3'b111: REGH[rda_int] <= rd[15:8];
+		endcase
+	end
 end
 
 reg [15:0]REG_1_REG;


### PR DESCRIPTION
The AVR engine (`rtl/avr/mega-core.v`/`mega-reg.v`/`mega-ram.v`) had a few cycle-timing deviations
from the AVR Instruction Set Manual, plus two interrupt-dispatch races that surfaced while fixing
them.

### Cycle-timing fixes

- **`OUT`/`IN`**: was 2 cycles; the ISA manual specifies 1. `OUT` now completes in 1 cycle and
  retires its SREG/SP/data-bus side effects on the next free bus cycle, via a dedicated
  pending-write state machine (`out_retire_pending`).
- **`CALL`**: was 3 cycles (1 short). Added the missing wait state; the second instruction word is
  latched before the fetch stream moves past it.
- **`IJMP`**: was 3 cycles (1 slow). Collapsed to 1 cycle via a combinational Z-register tap, with
  write-forwarding for a register written by the immediately preceding instruction.

### Two interrupt-dispatch races

Interrupt entry injects a synthetic `CALL` opcode through the same datapath a real `CALL` uses,
which exposed two races:

1. The synthetic word could be captured by `OUT`'s hold-and-release mechanism and misinterpreted on
   release, jumping the CPU to a garbage address.
2. A releasing hold could win priority over interrupt dispatch on the same cycle, silently dropping
   the interrupt instead of delaying it.

Fixed by gating interrupt dispatch on the same bus-hazard check a real `CALL` uses, instead of ever
routing through the `OUT` hold mechanism.

### Also included

- **RAM reset-clear width**: reset only cleared the first 256 bytes (an 8-bit loop counter on a
  wider address bus).
