### PR TITLE
Fix/oled clk sync rebased

### DIFF
--- a/Arduboy.sv
+++ b/Arduboy.sv
@@ -361,6 +361,7 @@ wire VSync, HSync, HBlank, VBlank;
 vgaHdmi vgaHdmi
 (
     .clock(clk_sys),
+    .clk_avr(clk_avr),
     .reset(reset),
     .oled_dc(oled_dc),
     .oled_clk(oled_clk),

--- a/rtl/vgaHdmi.v
+++ b/rtl/vgaHdmi.v
@@ -20,7 +20,8 @@ Editor : sublime text3, tab size (2)
 
 module vgaHdmi
 (
-  input clock,
+  input clock,     // clk_sys, 40MHz: video timing and framebuffer read
+  input clk_avr,   // 16MHz AVR clock; the domain that generates oled_clk
   input reset,
   input oled_dc,
   input oled_clk,
@@ -41,7 +42,21 @@ reg  [7:0] shiftReg;
 wire [7:0] shiftLeft = {shiftReg[6:0], oled_data};
 reg  [2:0] pageCount;
 
-always @ (posedge oled_clk or posedge reset) begin
+// oled_clk is not a real clock. In atmega_spi_m it is a combinational function
+// of two clk_avr registers (scl = sck_active & sckint), so clocking this block
+// off it leaves the whole display write path outside timing analysis and exposes
+// it to runt pulses from routing skew between those two registers -- and one
+// spurious edge desyncs shiftCount permanently, shifting the picture until reset.
+// Sample it in clk_avr, the domain that generates it, and detect the rising edge:
+// SPI mode 0 clocks data in on the rising edge, and scl only ever changes in
+// response to a clk_avr edge, so this captures exactly the same bits one clk_avr
+// cycle later. reset is generated in clk_avr too, so it is synchronous here now.
+reg        oled_clk_d;
+wire       oled_clk_rise = ~oled_clk_d & oled_clk;
+
+always @ (posedge clk_avr) begin
+  oled_clk_d <= oled_clk;
+
   if(reset) begin
     waddr         <= 0;
     invert        <= 0;
@@ -49,7 +64,7 @@ always @ (posedge oled_clk or posedge reset) begin
     shiftReg      <= 0;
     pageCount     <= 0;
   end
-  else begin
+  else if(oled_clk_rise) begin
     if (oled_dc) begin // data
       if (shiftCount == 3'b111) begin
         mem[waddr] <= shiftLeft;

--- a/rtl/vgaHdmi.v
+++ b/rtl/vgaHdmi.v
@@ -42,15 +42,12 @@ reg  [7:0] shiftReg;
 wire [7:0] shiftLeft = {shiftReg[6:0], oled_data};
 reg  [2:0] pageCount;
 
-// oled_clk is not a real clock. In atmega_spi_m it is a combinational function
-// of two clk_avr registers (scl = sck_active & sckint), so clocking this block
-// off it leaves the whole display write path outside timing analysis and exposes
-// it to runt pulses from routing skew between those two registers -- and one
-// spurious edge desyncs shiftCount permanently, shifting the picture until reset.
-// Sample it in clk_avr, the domain that generates it, and detect the rising edge:
-// SPI mode 0 clocks data in on the rising edge, and scl only ever changes in
-// response to a clk_avr edge, so this captures exactly the same bits one clk_avr
-// cycle later. reset is generated in clk_avr too, so it is synchronous here now.
+// oled_clk is not a real clock -- in atmega_spi_m it's a combinational function of
+// two clk_avr registers (scl = sck_active & sckint), so a routing-skew runt pulse
+// between them could desync shiftCount. Sampled here in clk_avr (the domain that
+// generates it) with rising-edge detection: SPI mode 0 samples on the rising edge,
+// and scl only changes in response to a clk_avr edge, so this captures the same
+// bits one clk_avr cycle later, synchronously.
 reg        oled_clk_d;
 wire       oled_clk_rise = ~oled_clk_d & oled_clk;
 

--- a/rtl/vgaHdmi.v
+++ b/rtl/vgaHdmi.v
@@ -20,8 +20,8 @@ Editor : sublime text3, tab size (2)
 
 module vgaHdmi
 (
-  input clock,     // clk_sys, 40MHz: video timing and framebuffer read
-  input clk_avr,   // 16MHz AVR clock; the domain that generates oled_clk
+  input clock,     // clk_sys, video timing
+  input clk_avr,   // generates oled_clk
   input reset,
   input oled_dc,
   input oled_clk,
@@ -42,12 +42,9 @@ reg  [7:0] shiftReg;
 wire [7:0] shiftLeft = {shiftReg[6:0], oled_data};
 reg  [2:0] pageCount;
 
-// oled_clk is not a real clock -- in atmega_spi_m it's a combinational function of
-// two clk_avr registers (scl = sck_active & sckint), so a routing-skew runt pulse
-// between them could desync shiftCount. Sampled here in clk_avr (the domain that
-// generates it) with rising-edge detection: SPI mode 0 samples on the rising edge,
-// and scl only changes in response to a clk_avr edge, so this captures the same
-// bits one clk_avr cycle later, synchronously.
+// oled_clk is combinational (scl = sck_active & sckint), not a real clock -- sample it
+// in clk_avr and edge-detect instead of clocking off it, to avoid a routing-skew runt
+// pulse desyncing shiftCount.
 reg        oled_clk_d;
 wire       oled_clk_rise = ~oled_clk_d & oled_clk;
 


### PR DESCRIPTION

`oled_clk` is combinational (`scl = sck_active & sckint` in `atmega_spi_m`), not a real clock.
Clocking `vgaHdmi`'s display-write block directly off it left that path outside timing analysis
and exposed it to a routing-skew runt pulse, which would permanently desync `shiftCount`.

Retimes the block into `clk_avr` (the domain that generates `oled_clk`) with rising-edge
detection instead. SPI mode 0 sampling and the captured bits are unchanged; reset is now
synchronous to `clk_avr` as well.

### Testing

Compiles clean (0 errors, 1505 warnings). Hardware-tested — no regressions, no visible change
in OLED behavior (expected: functionally equivalent, this closes a synthesis-timing gap rather
than any observed symptom).