### PR TITLE
atmega32u4: enable SPI receive path and expose MISO and chip selects

### DIFF
--- a/rtl/arduboy_board.v
+++ b/rtl/arduboy_board.v
@@ -18,6 +18,8 @@ module arduboy_board
     input status,
     output [2:0] RGB,
     output Buzzer1, Buzzer2, DC, spi_scl, spi_mosi,
+    input spi_miso,
+    output oled_cs, cart_cs,
     input uart_rx,
     output uart_tx
     );
@@ -48,6 +50,9 @@ atmega32u4 atmega32u4
     .PD4(DC),
     .PB1(spi_scl),
     .PB2(spi_mosi),
+    .PB3(spi_miso),
+    .PD6(oled_cs),
+    .PD1(cart_cs),
     .PD2(uart_rx),
     .PD3(uart_tx)
     );

--- a/rtl/avr/atmega32u4.v
+++ b/rtl/avr/atmega32u4.v
@@ -103,6 +103,8 @@ module atmega32u4 # (
     output PC6, PC7,
     output PD4,
     output PB1, PB2,
+    input PB3,
+    output PD1, PD6,
     input PD2,
     output PD3
     );
@@ -163,7 +165,6 @@ wire tim3_occ;
 wire tim4_oca;
 wire tim4_ocb;
 wire tim4_ocd;
-wire spi_miso;
 wire usb_ck_out;
 wire tim_ck_out;
 /* !IO ALTERNATIVE FUNCTION */
@@ -184,6 +185,8 @@ assign PB5 = tim1_oca_io_connect ? tim1_oca : ~(pb_out[5]);
 assign PC6 = tim3_oca_io_connect ? tim3_oca : pc_out[6];
 assign PC7 = tim4_ocap_io_connect ? tim4_oca : pc_out[7];
 assign PD4 = pd_out[4];
+assign PD1 = pd_out[1];
+assign PD6 = pd_out[6];
 
 /* Interrupt wires */
 wire ram_sel = |data_addr[`BUS_ADDR_DATA_LEN-1:8];
@@ -499,9 +502,10 @@ atmega_spi_m # (
     .BAUDRATE_CNT_LEN(0),
     .BAUDRATE_DIVIDER(0),
     .USE_TX("TRUE"),
-    .USE_RX("FALSE")
+    .USE_RX("TRUE")
 )spi(
     .rst(rst),
+    .halt(1'b0),
     .clk(clk),
     .addr_dat(data_addr[7:0]),
     .wr_dat(data_write & ~ram_sel),
@@ -514,7 +518,7 @@ atmega_spi_m # (
     .io_conn_slave(io_conn_slave),
 
     .scl(PB1),
-    .miso(spi_miso),
+    .miso(PB3),
     .mosi(PB2)
     );
 end


### PR DESCRIPTION
Re-port of 61c608e for the post-PR#21 real-pin-accurate module split. The SPI master was instantiated transmit-only and spi_miso was an internal wire driven by nothing, so the CPU could never read a byte.

atmega32u4.v (generic chip module): USE_RX enabled, miso wired to a real input port (PB3, the chip's actual hardware MISO pin per the ATmega32U4 datasheet); PD1/PD6 exposed as plain GPIO outputs matching the existing PD4 pattern. Also ties the previously-unconnected halt input low, same as the original fix.

arduboy_board.v (board wiring layer, didn't exist at the time of the original fix): exposes spi_miso/oled_cs/cart_cs and wires them to the new PB3/PD6/PD1 ports -- PD6/PD1 are bit-banged GPIO chip-selects on the real Arduboy PCB, not the chip's hardware SPI SS (PB0), confirmed via projects/arduboy-atmega-module/PROJECT.md's real-pin audit.

Same scope as the original: Arduboy.sv is untouched, so spi_miso is left unconnected at the very top, same limitation the original fix had. This enables the RX datapath and exposes real pins; it does not by itself wire any physical MISO source (e.g. a cart flash chip) -- that's separate, unstarted scope.