### PR TITLE
fix input-mode pull-up drive and antiphase audio mix

### DIFF
--- a/Arduboy.sv
+++ b/Arduboy.sv
@@ -36,8 +36,13 @@ assign HDMI_BLACKOUT = 0;
 assign HDMI_BOB_DEINT = 0;
 assign FB_FORCE_BLANK = 0;
 
-assign AUDIO_S     = 0;
-assign AUDIO_L     = {1'b0,{15{Buzzer1}}} + {1'b0,{15{Buzzer2}}};
+// Speaker is wired across Buzzer1/Buzzer2 with no ground reference (SPEAKER+/SPEAKER-) --
+// a two-terminal load responds only to the voltage difference between its terminals, so the
+// mix must be differential, not additive: same-state pins (00/11) produce silence, opposite
+// states produce a full-scale swing of the correct polarity. AUDIO_S=1 (signed) avoids the
+// unsigned bit-flip that would otherwise crush that swing to a couple of LSBs.
+assign AUDIO_S     = 1;
+assign AUDIO_L     = (Buzzer1 == Buzzer2) ? 16'sd0 : (Buzzer1 ? 16'sd32767 : -16'sd32767);
 assign AUDIO_R     = AUDIO_L;
 assign AUDIO_MIX   = 0;
 

--- a/Arduboy.sv
+++ b/Arduboy.sv
@@ -36,11 +36,9 @@ assign HDMI_BLACKOUT = 0;
 assign HDMI_BOB_DEINT = 0;
 assign FB_FORCE_BLANK = 0;
 
-// Speaker is wired across Buzzer1/Buzzer2 with no ground reference (SPEAKER+/SPEAKER-) --
-// a two-terminal load responds only to the voltage difference between its terminals, so the
-// mix must be differential, not additive: same-state pins (00/11) produce silence, opposite
-// states produce a full-scale swing of the correct polarity. AUDIO_S=1 (signed) avoids the
-// unsigned bit-flip that would otherwise crush that swing to a couple of LSBs.
+// Speaker is wired across Buzzer1/Buzzer2 with no ground reference, so the mix must be
+// differential, not additive. AUDIO_S=1 (signed) avoids the unsigned bit-flip that would
+// otherwise crush the swing to a couple of LSBs.
 assign AUDIO_S     = 1;
 assign AUDIO_L     = (Buzzer1 == Buzzer2) ? 16'sd0 : (Buzzer1 ? 16'sd32767 : -16'sd32767);
 assign AUDIO_R     = AUDIO_L;

--- a/rtl/avr/atmega-pio.v
+++ b/rtl/avr/atmega-pio.v
@@ -51,12 +51,8 @@ module atmega_pio # (
 reg [7:0]DDR;
 reg [7:0]PORT;
 
-// Per the ATmega32U4/644 datasheet, Table 10-1: DDR=1 drives PORT directly (Output Low/High);
-// DDR=0/PORT=1 is not floating either -- the internal pull-up sources current, which reads the
-// same as driven-high to anything downstream that isn't itself driving the pin low. Gating on
-// DDR here (forcing 0 whenever DDR=0) silently drops that pull-up drive -- the real bug behind
-// Tiny Trick's missing sound, which drives its speaker via PORTC writes with DDRC left at 0, a
-// real datasheet-documented technique (10.2.1), not a game bug.
+// DDR=1 drives PORT directly; DDR=0/PORT=1 sources the internal pull-up, which reads the same
+// as driven-high downstream (ATmega32U4/644 datasheet Table 10-1).
 assign io_out[0] = PORT[0];
 assign io_out[1] = PORT[1];
 assign io_out[2] = PORT[2];

--- a/rtl/avr/atmega-pio.v
+++ b/rtl/avr/atmega-pio.v
@@ -51,14 +51,20 @@ module atmega_pio # (
 reg [7:0]DDR;
 reg [7:0]PORT;
 
-assign io_out[0] = DDR[0] ? PORT[0] : 1'b0;
-assign io_out[1] = DDR[1] ? PORT[1] : 1'b0;
-assign io_out[2] = DDR[2] ? PORT[2] : 1'b0;
-assign io_out[3] = DDR[3] ? PORT[3] : 1'b0;
-assign io_out[4] = DDR[4] ? PORT[4] : 1'b0;
-assign io_out[5] = DDR[5] ? PORT[5] : 1'b0;
-assign io_out[6] = DDR[6] ? PORT[6] : 1'b0;
-assign io_out[7] = DDR[7] ? PORT[7] : 1'b0;
+// Per the ATmega32U4/644 datasheet, Table 10-1: DDR=1 drives PORT directly (Output Low/High);
+// DDR=0/PORT=1 is not floating either -- the internal pull-up sources current, which reads the
+// same as driven-high to anything downstream that isn't itself driving the pin low. Gating on
+// DDR here (forcing 0 whenever DDR=0) silently drops that pull-up drive -- the real bug behind
+// Tiny Trick's missing sound, which drives its speaker via PORTC writes with DDRC left at 0, a
+// real datasheet-documented technique (10.2.1), not a game bug.
+assign io_out[0] = PORT[0];
+assign io_out[1] = PORT[1];
+assign io_out[2] = PORT[2];
+assign io_out[3] = PORT[3];
+assign io_out[4] = PORT[4];
+assign io_out[5] = PORT[5];
+assign io_out[6] = PORT[6];
+assign io_out[7] = PORT[7];
 
 always @ (posedge rst or posedge clk)
 begin


### PR DESCRIPTION
Two small, related fixes needed together to fix Tiny Trick's audio:

**`atmega-pio.v`** — `io_out` forced 0 whenever a pin was configured as input (`DDR=0`), silently
dropping the ATmega32U4/644's internal pull-up (datasheet Table 10-1: `DDR=0`/`PORT=1` sources
current, same as driven-high downstream). Now reads `PORT` directly regardless of `DDR`. Shared by
every GPIO port, so this can affect any game.

**`Arduboy.sv`** — the real speaker is wired across `Buzzer1`/`Buzzer2` with no ground reference,
so the mix must be differential, not additive; it previously summed them as independent
magnitudes, so a true differential drive read as a near-constant level instead of a tone. Fixed
with a signed, equal-magnitude opposite-sign formula.

**Games fixed:** Tiny Trick's speaker was silent — needs both fixes together (`DDRC` left at 0 is
a real, datasheet-documented technique, not a game bug; the old mix formula couldn't represent an
antiphase drive as a tone regardless). Ardynia's chest-open sound, which drives the same two pins
as independent channels via `ArduboyPlaytune`, also plays correctly under the new mix formula.

**Testing:** Compiles clean, no new warnings. Conformance suite unchanged. Hardware-tested: Tiny
Trick's sound is correct, Ardynia's chest-open sound plays correctly, several other games tested
with no regressions.
