### PR TITLE
Fix ST -X/-Y/-Z cycle count: 2 cycles per AVR ISA Manual Table 5-2

### DIFF
--- a/rtl/avr/mega-core.v
+++ b/rtl/avr/mega-core.v
@@ -320,9 +320,9 @@ function bus_busy_user;
 			{`STEP1, `INSTRUCTION_STS},
 			{`STEP1, `INSTRUCTION_ST_X},
 			{`STEP1, `INSTRUCTION_ST_XP},
-			{`STEP1, `INSTRUCTION_ST_XN},  {`STEP2, `INSTRUCTION_ST_XN},
+			{`STEP1, `INSTRUCTION_ST_XN},
 			{`STEP1, `INSTRUCTION_ST_YZP},
-			{`STEP1, `INSTRUCTION_ST_YZN}, {`STEP2, `INSTRUCTION_ST_YZN},
+			{`STEP1, `INSTRUCTION_ST_YZN},
 			{`STEP1, `INSTRUCTION_PUSH}: bus_busy_user = 1'b1;
 			default: bus_busy_user = 1'b0;
 		endcase
@@ -495,7 +495,7 @@ begin
 		end
 		
 		{1'b1, `STEP2, `INSTRUCTION_LD_XN},
-		{1'b1, `STEP2, `INSTRUCTION_ST_XN}: 
+		{1'b1, `STEP1, `INSTRUCTION_ST_XN}: 
 		begin
 			if(ROM_ADDR_WIDTH > 16)
 				{ramp_bits, reg_rd} = {RAMPX, reg_rs2} - 1;
@@ -503,7 +503,7 @@ begin
 				reg_rd = reg_rs2 - 1;
 		end
 		{1'b1, `STEP2, `INSTRUCTION_LD_YZN},
-		{1'b1, `STEP2, `INSTRUCTION_ST_YZN}: 
+		{1'b1, `STEP1, `INSTRUCTION_ST_YZN}: 
 		begin
 			if(ROM_ADDR_WIDTH > 16)
 				{ramp_bits, reg_rd} = {pgm_data_registered[3] ? RAMPY : RAMPZ, reg_rs2} - 1;
@@ -941,11 +941,11 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZP},
 					{1'b1, `STEP0, `INSTRUCTION_ST_YZP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_YZN}: rda <= {3'b111, ~pgm_data_registered[3], 1'b0};
+					{1'b1, `STEP0, `INSTRUCTION_ST_YZN}: rda <= {3'b111, ~pgm_data_registered[3], 1'b0};
 					{1'b1, `STEP1, `INSTRUCTION_LD_XP},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_XN}: rda <= 5'b11010;
+					{1'b1, `STEP0, `INSTRUCTION_ST_XN}: rda <= 5'b11010;
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P}: rda <= 5'b11110;
 				endcase
 	/* Set "reg_rdm" */ /*************************************************************/
@@ -962,11 +962,11 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZP},
 					{1'b1, `STEP0, `INSTRUCTION_ST_YZP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_YZN},
+					{1'b1, `STEP0, `INSTRUCTION_ST_YZN},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XP},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
+					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P}: reg_rdm <= `REG_MODE_16_BIT;
 				endcase
 	/* Set "reg_rdw" */ /*************************************************************/
@@ -1011,14 +1011,14 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_ST_YZP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZN},
 					{1'b1, `STEP2, `INSTRUCTION_LD_YZN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_YZN},
+					{1'b1, `STEP0, `INSTRUCTION_ST_YZN},
 					{1'b1, `STEP2, `INSTRUCTION_LD_X},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XP},
 					{1'b1, `STEP2, `INSTRUCTION_LD_XP},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP2, `INSTRUCTION_LD_XN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
+					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP0, `INSTRUCTION_IN}, // IN-only: doesn't read reg_rs1, only writes via rda/reg_rdw -- independent of OUT's own (still 2-cycle) timing.
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R_P},
@@ -1101,7 +1101,6 @@ begin
 						else
 							data_addr_int <= reg_rs2 - 1;
 					end
-					{1'b1, `STEP2, `INSTRUCTION_ST_YZN}: data_addr_int <= data_addr_int;
 					{1'b1, `STEP1, `INSTRUCTION_LD_X}: 
 					begin
 						if(ROM_ADDR_WIDTH > 16) 
@@ -1147,7 +1146,6 @@ begin
 						else
 							data_addr_int <= reg_rs2 - 1;
 					end
-					{1'b1, `STEP2, `INSTRUCTION_ST_XN}: data_addr_int <= data_addr_int;
 					{1'b1, `STEP0, `INSTRUCTION_IN},
 					{1'b1, `STEP1, `INSTRUCTION_IN}: data_addr_int <= {pgm_data_registered[10:9],pgm_data_registered[3:0]} + 'h20;
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
@@ -1182,10 +1180,10 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_STS16},
 					{1'b1, `STEP1, `INSTRUCTION_STD},
 					{1'b1, `STEP1, `INSTRUCTION_ST_YZP},
-					{1'b1, `STEP2, `INSTRUCTION_ST_YZN},
+					{1'b1, `STEP1, `INSTRUCTION_ST_YZN},
 					{1'b1, `STEP1, `INSTRUCTION_ST_X},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XP},
-					{1'b1, `STEP2, `INSTRUCTION_ST_XN}: data_out_int <= reg_rs1;
+					{1'b1, `STEP1, `INSTRUCTION_ST_XN}: data_out_int <= reg_rs1;
 					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI}:
 					begin
 						if(pgm_data_registered[9])
@@ -1212,10 +1210,10 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_STS16},
 					{1'b1, `STEP1, `INSTRUCTION_STD},
 					{1'b1, `STEP1, `INSTRUCTION_ST_YZP},
-					{1'b1, `STEP2, `INSTRUCTION_ST_YZN},
+					{1'b1, `STEP1, `INSTRUCTION_ST_YZN},
 					{1'b1, `STEP1, `INSTRUCTION_ST_X},
 					{1'b1, `STEP1, `INSTRUCTION_ST_XP},
-					{1'b1, `STEP2, `INSTRUCTION_ST_XN},
+					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP1, `INSTRUCTION_STS},
 					{1'b1, `STEP1, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP1, `INSTRUCTION_OUT}: data_write_int <= 1'b1;
@@ -1321,11 +1319,9 @@ begin
 					{1'b1, `STEP1, `INSTRUCTION_LDD},
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_YZN},
 					{1'b1, `STEP1, `INSTRUCTION_LD_X},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XP},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_R_P},
 					{1'b1, `STEP1, `INSTRUCTION_LPM_ELPM}: state_cnt <= `STEP2;
@@ -1403,7 +1399,6 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_LD_YZN},
 					{1'b1, `STEP1, `INSTRUCTION_LD_YZN},
 					{1'b1, `STEP0, `INSTRUCTION_ST_YZN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_YZN},
 					{1'b1, `STEP0, `INSTRUCTION_LD_X},
 					{1'b1, `STEP1, `INSTRUCTION_LD_X},
 					{1'b1, `STEP0, `INSTRUCTION_ST_X},
@@ -1413,7 +1408,6 @@ begin
 					{1'b1, `STEP0, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP1, `INSTRUCTION_LD_XN},
 					{1'b1, `STEP0, `INSTRUCTION_ST_XN},
-					{1'b1, `STEP1, `INSTRUCTION_ST_XN},
 					{1'b1, `STEP0, `INSTRUCTION_CBI_SBI},
 					{1'b1, `STEP0, `INSTRUCTION_SBIC_SBIS},
 					{1'b1, `STEP0, `INSTRUCTION_LPM_R},


### PR DESCRIPTION
Pre-decrement stores took 3. Entries move down one state to match the working 2-cycle ST X+/Y+/Z+ forms; ST_XN/ST_YZN's STEP1 PC-freeze entries are removed so PC advances on the instruction's final state. Leaving a freeze there re-presents the next opcode on two consecutive STEP0 cycles and executes it twice. LD -X/-Y/-Z untouched, still 3-state.